### PR TITLE
Reduce confusion in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It does not require changes to existing robot code, since it is built on `rosbri
 - **No ROS node modification required**: Fully interoperable with existing systems
 
 ---
-## Supported ROS Commands
+## Features
 
 - **View all running ROS topics and types**
 - **View message type details**, including custom messages — no code changes needed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,11 +1,20 @@
 # Installation Guide
+Installation includes the following steps:
+- Install the MCP server
+  - Clone this repository
+  - Instal uv (Python virtual environment manager)
+- Install and configure the Language model client
+  - Instal any language model client (We demo with Claude Desktop)
+  - Configure the client to run the MCP server and connect automatically on launch.
+- Install and launch Rosbridge
 
-Follow these steps to set up the ROS MCP Server and connect it with a supported language model client (e.g., Claude Desktop).
+
+Below are detailed instructions for each of these steps. 
 
 ---
-# On the Host Machine (Where the LLM will be running)
+# 1. Install the MCP server (On the host machine where the LLM will be running)
 
-## 1. Clone the Repository
+## 1.1. Clone the Repository
 
 ```bash
 git clone https://github.com/robotmcp/ros-mcp-server.git
@@ -15,7 +24,7 @@ Note the **absolute path** to the cloned directory — you’ll need this later 
 
 ---
 
-## 2. Install UV (Python Virtual Environment Manager)
+## 1.2. Install UV (Python Virtual Environment Manager)
 
 You can install [`uv`](https://github.com/astral-sh/uv) using one of the following methods:
 
@@ -31,36 +40,27 @@ pip install uv
 
 ---
 
-## 3. Install a Language Model Client
+# 2. Install and configure a Language Model Client 
 
-Any LLM client that supports MCP can be used. We use **Claude Desktop** for testing and development.
+Any LLM client that supports MCP can be used. We use **Claude Desktop** for testing and development. This section has instructions for:
+- Linux (Ubuntu)
+- Windows (using WSL)
+- MacOS
 
-- **MacOS / Windows**: Download from [claude.ai](https://claude.ai/download)
-- **Linux (Unofficial)**: Use the community-supported [claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian)
 
----
+## 2a. Linux (Ubuntu)
+### Download Claude 
+- From the community-supported [claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian)
 
-## 4. Configure the Language Model Client (Specific to Claude Desktop)
-
-### Locate and edit the `claude_desktop_config.json` file:
-
-- **MacOS**
-```bash
-code ~/Library/Application\ Support/Claude/claude_desktop_config.json
-```
-
-- **Linux (Ubuntu)**
+### Configure the client to launch the MCP server
+- Locate and edit the `claude_desktop_config.json` file:
+- (If the file does not exist, create it)
 ```bash
 code ~/.config/Claude/claude_desktop_config.json
 ```
 
-- **Windows (PowerShell)**
-```powershell
-code $env:AppData\Claude\claude_desktop_config.json
-```
-
-### Add the following to the `"mcpServers"` section of the JSON file
-Make sure to replace `<ABSOLUTE_PATH>` with the path to your `ros-mcp-server` folder:
+- Add the following to the `"mcpServers"` section of the JSON file
+- Make sure to replace `<ABSOLUTE_PATH>` with the path to your `ros-mcp-server` folder:
 
 ```json
 {
@@ -78,9 +78,55 @@ Make sure to replace `<ABSOLUTE_PATH>` with the path to your `ros-mcp-server` fo
 }
 ```
 
-✅ **Tip:** If on Windows, using [WSL](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-US&gl=US) is also a strong option - with Claude running on Windows and the MCP server running on WSL. 
+---
+## 2b. MacOS
+### Download Claude 
+- From [claude.ai](https://claude.ai/download)
 
-Use the below configuration for this, making sure to: 
+### Configure the Host to launch the MCP server
+- Locate and edit the `claude_desktop_config.json` file:
+- (If the file does not exist, create it)
+```bash
+code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+- Add the following to the `"mcpServers"` section of the JSON file
+- Make sure to replace `<ABSOLUTE_PATH>` with the path to your `ros-mcp-server` folder:
+
+```json
+{
+  "mcpServers": {
+    "ros-mcp-server": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/<ABSOLUTE_PATH>/ros-mcp-server",
+        "run",
+        "server.py"
+      ]
+    }
+  }
+}
+```
+
+## 2c. Windows (Using WSL)
+This will have Claude running on Windows and the MCP server running on WSL.
+
+### Install WSL (Windows Subsystem for Linux)
+- [Downlowd WSL](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-US&gl=US) 
+
+### Download your client - Claude 
+- From [claude.ai](https://claude.ai/download)
+
+### Configure the client to launch the MCP server
+- Locate and edit the `claude_desktop_config.json` file:
+- (If the file does not exist, create it)
+```bash
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+- Add the following to the `"mcpServers"` section of the JSON file
+- Make sure to replace `<ABSOLUTE_PATH>` with the path to your `ros-mcp-server` folder:
 - Set the **full WSL path** to your `uv` installation (e.g., `/home/youruser/.local/bin/uv`)
 - Use the correct **WSL distribution name** (e.g., `"Ubuntu-22.04"`)
 ```json
@@ -100,8 +146,8 @@ Use the below configuration for this, making sure to:
   }
 }
 ```
----
-## 5. Test that the Host (Claude) can connect to the MCP server
+
+# 3. Test that the Client (Claude) can connect to the MCP server
 
 - Launch your host and check connection status. 
 - Below is an image of what that looks like in Claude. The ros-mcp-server should be visible in your list of tools.
@@ -111,9 +157,9 @@ Use the below configuration for this, making sure to:
 </p>
 ---
 
-# On the Target Robot (Where ROS will be running)
+# 4. Install and run rosbridge (On the target robot Where ROS will be running)
 
-## 1. Install `rosbridge_server`
+## 3.1. Install `rosbridge_server`
 
 This package is required for MCP to interface with ROS or ROS 2 via WebSocket. It needs to be installed on the same machine that is running ROS.
 
@@ -128,7 +174,7 @@ sudo apt install ros-noetic-rosbridge-server
 sudo apt install ros-humble-rosbridge-server
 ```
 
-## Test rosbridge server by launching in your ROS environment:
+## 3.2. Launch rosbridge in your ROS environment:
 ```bash
 # ROS 1
 roslaunch rosbridge_server rosbridge_websocket.launch

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ Any LLM client that supports MCP can be used. We use **Claude Desktop** for test
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
-code ~/.config/Claude/claude_desktop_config.json
+~/.config/Claude/claude_desktop_config.json
 ```
 
 - Add the following to the `"mcpServers"` section of the JSON file
@@ -87,7 +87,7 @@ code ~/.config/Claude/claude_desktop_config.json
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
-code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
 - Add the following to the `"mcpServers"` section of the JSON file
@@ -122,7 +122,7 @@ This will have Claude running on Windows and the MCP server running on WSL.
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
-code ~/.config/Claude/claude_desktop_config.json
+~/.config/Claude/claude_desktop_config.json
 ```
 
 - Add the following to the `"mcpServers"` section of the JSON file


### PR DESCRIPTION
Split out the instructions for installing the Language model client into windows, mac and linux. 
Also added a line that if the config file does not exist, to create it. 