### PR TITLE
Change Image Save Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,4 @@ pyrightconfig.json
 .vscode/
 
 # camera
-.camera/
+/camera/*

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ from utils.network_utils import ping_ip_and_port
 
 from fastmcp.utilities.types import Image
 from PIL import Image as PILImage
+import io
 
 # ROS bridge connection settings
 ROSBRIDGE_IP = "127.0.0.1"  # Default is localhost. Replace with your local IPor set using the LLM.
@@ -1102,13 +1103,13 @@ def analyze_previously_received_image():
     """
     Analyze the received image.
 
-    This tool loads the previously saved image from './camera/received_image.png'
+    This tool loads the previously saved image from './camera/received_image.jpeg'
     (which must have been created by 'parse_image' or 'subscribe_once'), and converts
     it into an MCP-compatible ImageContent format so that the LLM can interpret it.
     """
-    path = "./camera/received_image.png"
+    path = "./camera/received_image.jpeg"
     if not os.path.exists(path):
-        return {"error": "No previously received image found at ./camera/received_image.png"}
+        return {"error": "No previously received image found at ./camera/received_image.jpeg"}
     image = PILImage.open(path)
     return _encode_image_to_imagecontent(image)
 
@@ -1121,13 +1122,12 @@ def _encode_image_to_imagecontent(image):
         image (PIL.Image.Image): The image to encode.
 
     Returns:
-        ImageContent: PNG-encoded image wrapped in an ImageContent object.
+        ImageContent: JPEG-encoded image wrapped in an ImageContent object.
     """
-    import io
     buffer = io.BytesIO()
-    image.save(buffer, format="PNG")
+    image.save(buffer, format="JPEG")
     img_bytes = buffer.getvalue()
-    img_obj = Image(data=img_bytes, format="png")
+    img_obj = Image(data=img_bytes, format="jpeg")
     return img_obj.to_image_content()
 
 if __name__ == "__main__":

--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -81,7 +81,7 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
     if not os.path.exists("./camera"):
         os.makedirs("./camera")
 
-    success = cv2.imwrite("./camera/received_image.jpeg", img_cv) # Save as JPEG
+    success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95]) # Save as JPEG with quality 95
     if success:
         return result if isinstance(result, dict) else None
     else:

--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -81,7 +81,7 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
     if not os.path.exists("./camera"):
         os.makedirs("./camera")
 
-    success = cv2.imwrite("./camera/received_image.png", img_cv)
+    success = cv2.imwrite("./camera/received_image.jpeg", img_cv) # Save as JPEG
     if success:
         return result if isinstance(result, dict) else None
     else:

--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -77,15 +77,18 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
     except ValueError as e:
         print(f"[Image] Reshape error: {e}")
         return None
-    
+
     if not os.path.exists("./camera"):
         os.makedirs("./camera")
 
-    success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95]) # Save as JPEG with quality 95
+    success = cv2.imwrite(
+        "./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95]
+    )  # Save as JPEG with quality 95
     if success:
         return result if isinstance(result, dict) else None
     else:
         return None
+
 
 class WebSocketManager:
     def __init__(self, ip: str, port: int, default_timeout: float = 2.0):


### PR DESCRIPTION
The current image format used for receiving and analyzing images is PNG. While PNG provides superior image quality through lossless compression, its larger file size can cause errors when passed to the `analyze_previously_received_image` function, which has a 1MB input limitation. 
This change switches the image storage format from PNG to JPEG. After switching to JPEG, testing confirmed that FHD (1920×1080) images can be stored and analyzed without issues.