### PR TITLE
Added streamable-http transport layer option for ChatGPT. Default is still stdio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ pyrightconfig.json
 
 # .vscode
 .vscode/
+.vs/
 
 # camera
 .camera/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ros-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "MCP tool server for ROS using rosbridge WebSocket"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -1141,12 +1141,19 @@ if __name__ == "__main__":
         # stdio doesn't need host/port
         mcp.run(transport="stdio")
 
-    elif MCP_TRANSPORT == "streamable-http":
-        # read host/port only for HTTP transport
+    elif MCP_TRANSPORT in {"http", "streamable-http"}:
+        # http and streamable-http both require host/port
         print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
-        mcp.run(transport="streamable-http", host=MCP_HOST, port=MCP_PORT)
+        mcp.run(transport=MCP_TRANSPORT, host=MCP_HOST, port=MCP_PORT)
 
+    elif MCP_TRANSPORT == "sse":
+        print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
+        print("Currently unsupported. "
+              "Use 'stdio', 'http', or 'streamable-http'.")
+        mcp.run(transport=MCP_TRANSPORT, host=MCP_HOST, port=MCP_PORT)
+    
     else:
         raise ValueError(
-            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. Use 'stdio' or 'streamable-http'."
+            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. "
+            "Use 'stdio', 'http', or 'streamable-http'."
         )

--- a/server.py
+++ b/server.py
@@ -13,9 +13,14 @@ from PIL import Image as PILImage
 
 # ROS bridge connection settings
 ROSBRIDGE_IP = "127.0.0.1"  # Default is localhost. Replace with your local IPor set using the LLM.
-ROSBRIDGE_PORT = (
-    9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
-)
+ROSBRIDGE_PORT = 9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
+
+# MCP transport settings
+MCP_TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio").lower() # Default is stdio. 
+
+# MCP connection settings (streamable-http)
+MCP_HOST = os.getenv("MCP_HOST", "127.0.0.1") # Default is localhost. Replace with the address of your remote MCP server.
+MCP_PORT = int(os.getenv("MCP_PORT", "9000")) # Default is 9000. Replace with the port of your remote MCP server.
 
 # Initialize MCP server and WebSocket manager
 mcp = FastMCP("ros-mcp-server")
@@ -1131,8 +1136,17 @@ def _encode_image_to_imagecontent(image):
     return img_obj.to_image_content()
 
 if __name__ == "__main__":
-    transport = os.getenv("MCP_TRANSPORT", "stdio")  # "stdio" or "http"
-    if transport == "http":
-        mcp.run(transport=transport)
-    else:
+
+    if MCP_TRANSPORT == "stdio":
+        # stdio doesn't need host/port
         mcp.run(transport="stdio")
+
+    elif MCP_TRANSPORT == "streamable-http":
+        # read host/port only for HTTP transport
+        print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
+        mcp.run(transport="streamable-http", host=MCP_HOST, port=MCP_PORT)
+
+    else:
+        raise ValueError(
+            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. Use 'stdio' or 'streamable-http'."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 4
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -1213,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "ros-mcp-server"
-version = "0.2.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 4
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",


### PR DESCRIPTION
Added option for streamable-http transport layer. MCP_TRANSPORT, MCP_PORT and MCP_HOST should be set as env variables. Default is still stdio.

This is needed to work with ChatGPT, as it does not support stdio transport layer.