### PR TITLE
Updated uv.lock to fix version mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ros-mcp-server"
-version = "0.2.0"
+version = "2.1.0"
 description = "MCP tool server for ROS using rosbridge WebSocket"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1213,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "ros-mcp-server"
-version = "0.2.0"
+version = "2.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
The version of uv.lock also needs to be updated.