### PR TITLE
Added HTTP-based ChatGPT integration to MCP server with example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ pyrightconfig.json
 
 # .vscode
 .vscode/
+.vs/
 
 # camera
 .camera/

--- a/examples/6_chatgpt/README.md
+++ b/examples/6_chatgpt/README.md
@@ -1,0 +1,249 @@
+# ChatGPT Desktop with ROS-MCP-Server
+
+## Prerequisites
+
+### Prepare host machine (MCP Server)
+
+* Installation of ChatGPT Desktop. \[chatgpt.com/download] or Microsoft Store.
+* Installation of WSL (Linux).
+
+### Prepare target robot (ROS)
+
+* Installation of Ubuntu or WSL (Windows Subsystem for Linux).
+* Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow, this toturial \[https://wiki.ros.org/ROS/Tutorials]
+
+# Tutorial
+
+## 1.1 Installation on Host Machine
+
+### Install dependencies
+
+* Install [`uv`](https://github.com/astral-sh/uv) using one of the following methods:
+
+    <details>
+	<summary><strong>Option A: PowerShell (Windows)</strong></summary>
+
+	```bash
+	winget install --id=astral-sh.uv -e
+	```
+	or
+	```bash
+	pip install uv
+	```
+	
+	</details>
+
+ 	<details>
+	<summary><strong>Option B: WSL (Linux) </strong></summary>
+
+	```bash
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+	```
+	or
+	```bash
+	pip install uv
+	```
+	or
+	```bash
+	sudo snap install --classic astral-uv
+	```
+	</details>
+
+* Install [`ngrok`](https://dashboard.ngrok.com/get-started/setup/linux) using one of the following methods:
+	
+	<details>
+ 	<summary><strong>Option A: PowerShell (Windows)</strong></summary>
+	
+	Install from Microsoft Store or from [here](https://dashboard.ngrok.com/get-started/setup/windows)
+    </details>
+
+	<details>
+	<summary><strong>Option B: WSL (Linux)</strong></summary>
+	
+	Using Apt:
+	
+	```bash
+	curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \\
+	  | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \\
+	  \&\& echo "deb https://ngrok-agent.s3.amazonaws.com bookworm main" \\
+	  | sudo tee /etc/apt/sources.list.d/ngrok.list \\
+	  \&\& sudo apt update \\
+	  \&\& sudo apt install ngrok
+	```
+	or snap:
+	```bash
+	sudo snap install ngrok
+	```
+	</details>
+
+* Login or create your account at [`ngrok`](https://dashboard.ngrok.com/login)
+* Navigate to [`Your Authtoken`](https://dashboard.ngrok.com/get-started/your-authtoken)
+* Copy your `Authtoken` to clipboard `<YOUR_AUTHTOKEN>`
+* Activate `ngrok` with the following command, replacing `<YOUR_AUTHTOKEN>`:
+
+```bash
+ngrok config add-authtoken <YOUR_AUTHTOKEN>
+```
+* Obtain a static domain in `ngrok` by navigating to [Domains](https://dashboard.ngrok.com/domains)
+* It should look be something like: `abc123-xyz789.ngrok-free.app`
+* Save the ROS-MCP url domain, replacing it with yours.
+
+	<details>
+	<summary><strong>Option A: PowerShell (Windows)</strong></summary>
+
+	```bash
+	$env:MCP_DOMAIN=abc123-xyz789.ngrok-free.app
+	```
+	</details>
+
+	<details>
+	<summary><strong>Option B: WSL (Linux)</strong></summary>
+
+	```bash
+	export MCP_DOMAIN=abc123-xyz789.ngrok-free.app
+	```
+	</details>
+
+* In WSL (Linux), consider adding all your `MCP` variable to `.bashrc`
+
+```bash
+export MCP_HOST=127.0.0.1
+export MCP_PORT=9000
+export MCP_DOMAIN=abc123-xyz789.ngrok-free.app
+```
+
+### Install ROS-MCP Server
+
+*  On your Host Machine, clone the repository and navigate to the ROS-MCP Server folder.
+
+```bash
+git clone https://github.com/robotmcp/ros-mcp-server.git
+cd ros-mcp-server
+```
+
+
+## 1.2 Run ROS-MCP Server
+
+
+
+* Run the ROS-MCP using one of the following:
+		
+	<details>
+	<summary><strong>Option A: PowerShell (Windows)</strong></summary>
+
+	In PowerShell, set the tranport protocol:
+	
+	```bash
+	$env:MCP_TRANSPORT="streamable-http" 
+	```
+	
+	If you installed `uv` used the following:
+	```bash
+
+	uv run server.py
+	```
+	
+	Otherwise you have to install all the dependencies manually and run:
+
+	```bash
+	python server.py
+	```
+	
+	</details>
+
+	<details>
+	<summary><strong>Option B: WSL (Linux)</strong></summary>
+
+	Open WSL
+
+	Run the following:
+	```bash
+	export MCP_TRANSPORT="streamable-http"
+	uv run server.py
+	```
+
+	or
+
+	```bash
+	cd scripts
+	launch_mcp_server.sh
+	```
+	</details>
+
+* By default, the server should start at `127.0.0.1:9000`, you can set `MCP_HOST` and `MCP_PORT` variables as needed
+
+
+
+## 1.3 Tunnel ROS-MCP Server 
+
+* On your host machine, launch `ngrok` with one of the following:
+
+  	<details>
+	<summary><strong>Option A: PowerShell (Windows)</strong></summary>
+
+	In PowerShell, set the local port to tunnel:
+	
+	```bash
+	$env:MCP_PORT=9000
+	$env:MCP_DOMAIN=<YOUR_DOMAIN>
+	```
+	Run `ngrok` to tunnel your ROS-MCP server
+	
+	```bash
+	ngrok http --url=$env:MCP_DOMAIN $env:MCP_PORT
+	```
+	</details>
+
+	<details>
+	<summary><strong>Option B: WSL (Linux)</strong></summary>
+
+	In WSL, set the local port to tunnel:
+	```bash
+	export MCP_PORT=9000
+    export MCP_DOMAIN=<YOUR_DOMAIN>
+	```
+ 	Run `ngrok` to tunnel your ROS-MCP server
+	```bash
+	ngrok http --url=${MCP_DOMAIN} ${MCP_PORT}
+	```
+	Or you can also launch:
+	```bash
+	launch_mcp_tunnel_.sh
+	```
+ 	</details>
+
+* Once you launch `ngrok`, verify your public url domain:
+
+```bash
+https://abc123xyz.ngrok-free.app -> http://localhost:9000
+```
+
+
+## 1.4 Connect ROS-MCP to ChatGPT
+
+* Open ChatGPT Desktop
+* Navigate to Settings (Bottom Left)
+* Open Connectors
+* Create and fill the following:
+
+	- Name: *ROS-MCP Server**
+	- Description: *An MCP Server to connect with ROS/ROS2*
+	- MCP Server URL: `https://abc123-xyz789.ngrok-free.app/mcp` (don't forget to replace with your domain and add the `\mcp`)
+	- Authention: *No authentication*
+	- I trust this application
+
+* In ChatGPT, start a new Chat, navigate to `+` > `Developer Mode` > `Add sources` > Activate `ROS-MCP Server`
+
+## 1.5 Run ROS on Target Machine
+
+In WSL, launch `rosbridge` and `turtlesim`
+
+```bash
+source /opt/ros/jazzy/setup.bash
+ros2 launch rosbridge_server rosbridge_websocket_launch.xml & ros2 run turtlesim turtlesim_node
+```
+
+## Environment
+
+* Ubuntu 22.04
+* ROS 2 Jazzy

--- a/examples/6_chatgpt/README.md
+++ b/examples/6_chatgpt/README.md
@@ -187,7 +187,7 @@ cd ros-mcp-server
 	$env:MCP_PORT=9000
 	$env:MCP_DOMAIN=<YOUR_DOMAIN>
 	```
-	Run `ngrok` to tunnel your ROS-MCP server
+	Run `ngrok` to tunnel your ROS-MCP server.
 	
 	```bash
 	ngrok http --url=$env:MCP_DOMAIN $env:MCP_PORT
@@ -202,7 +202,7 @@ cd ros-mcp-server
 	export MCP_PORT=9000
     export MCP_DOMAIN=<YOUR_DOMAIN>
 	```
- 	Run `ngrok` to tunnel your ROS-MCP server
+ 	Run `ngrok` to tunnel your ROS-MCP server.
 	```bash
 	ngrok http --url=${MCP_DOMAIN} ${MCP_PORT}
 	```
@@ -212,11 +212,11 @@ cd ros-mcp-server
 	```
  	</details>
 
-* Once you launch `ngrok`, verify your public url domain:
+* Once you launch `ngrok`, verify your public url domain, it should be the same as `MCP_DOMAIN`.
 
-```bash
-https://abc123xyz.ngrok-free.app -> http://localhost:9000
-```
+	```bash
+	https://abc123xyz.ngrok-free.app -> http://localhost:9000
+	```
 
 
 ## 1.4 Connect ROS-MCP to ChatGPT
@@ -226,7 +226,7 @@ https://abc123xyz.ngrok-free.app -> http://localhost:9000
 * Open Connectors
 * Create and fill the following:
 
-	- Name: *ROS-MCP Server**
+	- Name: *ROS-MCP Server*
 	- Description: *An MCP Server to connect with ROS/ROS2*
 	- MCP Server URL: `https://abc123-xyz789.ngrok-free.app/mcp` (don't forget to replace with your domain and add the `\mcp`)
 	- Authention: *No authentication*
@@ -243,7 +243,16 @@ source /opt/ros/jazzy/setup.bash
 ros2 launch rosbridge_server rosbridge_websocket_launch.xml & ros2 run turtlesim turtlesim_node
 ```
 
-## Environment
+or
 
-* Ubuntu 22.04
+```bash
+launch_ros.sh
+```
+
+## Test Host Machine
+* Windows 11
+* WSL with Ubuntu 22.04
+ 
+## Test Target Machine
+* WSL with Ubuntu 22.04
 * ROS 2 Jazzy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ros-mcp-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "MCP tool server for ROS using rosbridge WebSocket"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/launch_mcp_server.sh
+++ b/scripts/launch_mcp_server.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Colors for log output
+BLUE='\033[1;34m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Starting MCP server environment...${NC}"
+
+# 0. Use MCP_TRANSPORT. You can add MCP_HOST / MCP_PORT if needed, otherwise fallback to default.
+export MCP_TRANSPORT="streamable-http"
+
+# 1. Check if MCP server is running
+if pgrep -f ros-mcp-server > /dev/null; then
+  echo -e "${YELLOW}[mcp-server]${NC} is already running. Continuing without starting a new instance."
+  MCP_PID=$(pgrep -f ros-mcp-server | head -n1)
+else 
+  # 2. Start MCP server
+  echo -e "${GREEN}[mcp-server]${NC} Launching MCP server..."
+  # Run with uv (already in pyproject.toml)
+  uv run ../server.py &
+  MCP_PID=$!
+fi
+
+echo -e "${GREEN}[mcp-server]${NC} mcp-server PID:  $MCP_PID"
+
+# 3. Trap to clean up processes on exit
+trap "echo -e '${GREEN}[mcp-server] ${NC}Stopping MCP processes...'; kill -9 $MCP_PID" SIGINT SIGTERM
+
+# 4. Keep script running, showing logs
+wait

--- a/scripts/launch_mcp_tunnel.sh
+++ b/scripts/launch_mcp_tunnel.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Colors for log output
+BLUE='\033[1;34m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Starting MCP ngrok tunneling...${NC}"
+
+# 1. Check if MCP server is running
+if pgrep -f ngrok > /dev/null; then
+  echo -e "${YELLOW}[mcp-server]${NC} is already running. Continuing without starting a new instance."
+  NGROK_PID=$(pgrep -f ngrok | head -n1)
+else 
+  # 2. Start ngrok tunnel
+  echo -e "${GREEN}[mcp-ngrok]${NC} Exposing MCP server via ngrok tunnel..."
+  ngrok http --url=${MCP_DOMAIN} ${MCP_PORT} &
+  NGROK_PID=$!
+fi
+
+echo -e "${GREEN}[mcp-ngrok]${NC} mcp-ngrok PID:  $NGROK_PID"
+
+# 3. Trap to clean up processes on exit
+trap "echo -e '${GREEN}[mcp-ngrok] ${NC}Stopping ngrok processes...'; kill -9 $NGROK_PID" SIGINT SIGTERM
+
+# 4. Keep script running, showing logs
+wait

--- a/scripts/launch_ros.sh
+++ b/scripts/launch_ros.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Colors
+BLUE='\033[1;34m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}Starting ROS 2 environment...${NC}"
+
+# 0. Source ROS 2 environment
+echo -e "${GREEN}[rosjazzy]${NC} Source ROS 2 Jazzy (change according to your distro)..."
+source /opt/ros/jazzy/setup.bash
+
+# 1. Check if rosbridge is already running
+if pgrep -f rosbridge_websocket > /dev/null; then
+  echo -e "${YELLOW}[rosbridge]${NC} is already running. Killing old instance..."
+  ROSBRIDGE_PIDS=($(pgrep -f "rosbridge_websocket"))
+  ROSBRIDGE_PID1=${ROSBRIDGE_PIDS[0]:-}
+  ROSBRIDGE_PID2=${ROSBRIDGE_PIDS[1]:-}
+  [ -n "$ROSBRIDGE_PID1" ] && kill -9 "$ROSBRIDGE_PID1"
+  [ -n "$ROSBRIDGE_PID2" ] && kill -9 "$ROSBRIDGE_PID2"
+fi
+
+# 3a. Start rosbridge
+echo -e "${GREEN}[rosbridge]${NC} Launching rosbridge..."
+ros2 launch rosbridge_server rosbridge_websocket_launch.xml port:=9090 &
+ROSBRIDGE_PIDS=($(pgrep -f "rosbridge_websocket" | head -n2))
+
+# 3b. Start turtlesim
+echo -e "${GREEN}[rosturtle]${NC} Launching turtlesim..."
+ros2 run turtlesim turtlesim_node &
+
+sleep 1
+
+# 3c. Store PIDs
+echo -e "${GREEN}[rosjazzy]${NC} All services launched.${NC}"
+
+ROSBRIDGE_PIDS=($(pgrep -f "rosbridge_websocket" | head -n2))
+ROSBRIDGE_PID1=${ROSBRIDGE_PIDS[0]}
+ROSBRIDGE_PID2=${ROSBRIDGE_PIDS[1]}
+TURTLESIM_PID=$(pgrep -f turtlesim_node | head -n1)
+echo "  • rosbridge PID:   $ROSBRIDGE_PID1"
+echo "  • rosbridge PID:   $ROSBRIDGE_PID2"
+echo "  • turtlesim PID:   $TURTLESIM_PID"
+
+# 3. Trap to clean up processes on exit
+trap "echo -e '${GREEN}[rosjazzy] ${NC}Stopping ROS processes...'; kill -9 $TURTLESIM_PID $ROSBRIDGE_PID1 $ROSBRIDGE_PID2" SIGINT SIGTERM
+
+# 4. Keep script running, showing logs
+wait
+

--- a/server.py
+++ b/server.py
@@ -1141,12 +1141,19 @@ if __name__ == "__main__":
         # stdio doesn't need host/port
         mcp.run(transport="stdio")
 
-    elif MCP_TRANSPORT == "streamable-http":
-        # read host/port only for HTTP transport
+    elif MCP_TRANSPORT in {"http", "streamable-http"}:
+        # http and streamable-http both require host/port
         print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
-        mcp.run(transport="streamable-http", host=MCP_HOST, port=MCP_PORT)
+        mcp.run(transport=MCP_TRANSPORT, host=MCP_HOST, port=MCP_PORT)
 
+    elif MCP_TRANSPORT == "sse":
+        print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
+        print("Currently unsupported. "
+              "Use 'stdio', 'http', or 'streamable-http'.")
+        mcp.run(transport=MCP_TRANSPORT, host=MCP_HOST, port=MCP_PORT)
+    
     else:
         raise ValueError(
-            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. Use 'stdio' or 'streamable-http'."
+            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. "
+            "Use 'stdio', 'http', or 'streamable-http'."
         )

--- a/server.py
+++ b/server.py
@@ -13,9 +13,14 @@ from PIL import Image as PILImage
 
 # ROS bridge connection settings
 ROSBRIDGE_IP = "127.0.0.1"  # Default is localhost. Replace with your local IPor set using the LLM.
-ROSBRIDGE_PORT = (
-    9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
-)
+ROSBRIDGE_PORT = 9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
+
+# MCP transport settings
+MCP_TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio").lower() # Default is stdio. 
+
+# MCP connection settings (streamable-http)
+MCP_HOST = os.getenv("MCP_HOST", "127.0.0.1") # Default is localhost. Replace with the address of your remote MCP server.
+MCP_PORT = int(os.getenv("MCP_PORT", "9000")) # Default is 9000. Replace with the port of your remote MCP server.
 
 # Initialize MCP server and WebSocket manager
 mcp = FastMCP("ros-mcp-server")
@@ -1131,8 +1136,17 @@ def _encode_image_to_imagecontent(image):
     return img_obj.to_image_content()
 
 if __name__ == "__main__":
-    transport = os.getenv("MCP_TRANSPORT", "stdio")  # "stdio" or "http"
-    if transport == "http":
-        mcp.run(transport=transport)
-    else:
+
+    if MCP_TRANSPORT == "stdio":
+        # stdio doesn't need host/port
         mcp.run(transport="stdio")
+
+    elif MCP_TRANSPORT == "streamable-http":
+        # read host/port only for HTTP transport
+        print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
+        mcp.run(transport="streamable-http", host=MCP_HOST, port=MCP_PORT)
+
+    else:
+        raise ValueError(
+            f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. Use 'stdio' or 'streamable-http'."
+        )

--- a/server.py
+++ b/server.py
@@ -13,14 +13,20 @@ from PIL import Image as PILImage
 
 # ROS bridge connection settings
 ROSBRIDGE_IP = "127.0.0.1"  # Default is localhost. Replace with your local IPor set using the LLM.
-ROSBRIDGE_PORT = 9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
+ROSBRIDGE_PORT = (
+    9090  # Rosbridge default is 9090. Replace with your rosbridge port or set using the LLM.
+)
 
 # MCP transport settings
-MCP_TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio").lower() # Default is stdio. 
+MCP_TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio").lower()  # Default is stdio.
 
 # MCP connection settings (streamable-http)
-MCP_HOST = os.getenv("MCP_HOST", "127.0.0.1") # Default is localhost. Replace with the address of your remote MCP server.
-MCP_PORT = int(os.getenv("MCP_PORT", "9000")) # Default is 9000. Replace with the port of your remote MCP server.
+MCP_HOST = os.getenv(
+    "MCP_HOST", "127.0.0.1"
+)  # Default is localhost. Replace with the address of your remote MCP server.
+MCP_PORT = int(
+    os.getenv("MCP_PORT", "9000")
+)  # Default is 9000. Replace with the port of your remote MCP server.
 
 # Initialize MCP server and WebSocket manager
 mcp = FastMCP("ros-mcp-server")
@@ -403,7 +409,9 @@ def subscribe_once(
                 unsubscribe_msg = {"op": "unsubscribe", "topic": topic}
                 ws_manager.send(unsubscribe_msg)
                 if "Image" in msg_type:
-                    return {"message": "Image received successfully and saved in the MCP server. Run the 'analyze_image' tool to analyze it"}
+                    return {
+                        "message": "Image received successfully and saved in the MCP server. Run the 'analyze_image' tool to analyze it"
+                    }
                 else:
                     return {"msg": msg_data.get("msg", {})}
 
@@ -599,7 +607,10 @@ def subscribe_for_duration(
     )
 )
 def publish_for_durations(
-    topic: str = "", msg_type: str = "", messages: List[Dict[str, Any]] = [], durations: List[float] = []
+    topic: str = "",
+    msg_type: str = "",
+    messages: List[Dict[str, Any]] = [],
+    durations: List[float] = [],
 ) -> dict:
     """
     Publish a sequence of messages to a given ROS topic with delays in between.
@@ -1129,14 +1140,15 @@ def _encode_image_to_imagecontent(image):
         ImageContent: PNG-encoded image wrapped in an ImageContent object.
     """
     import io
+
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     img_bytes = buffer.getvalue()
     img_obj = Image(data=img_bytes, format="png")
     return img_obj.to_image_content()
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     if MCP_TRANSPORT == "stdio":
         # stdio doesn't need host/port
         mcp.run(transport="stdio")
@@ -1148,10 +1160,9 @@ if __name__ == "__main__":
 
     elif MCP_TRANSPORT == "sse":
         print(f"Transport: {MCP_TRANSPORT} -> http://{MCP_HOST}:{MCP_PORT}")
-        print("Currently unsupported. "
-              "Use 'stdio', 'http', or 'streamable-http'.")
+        print("Currently unsupported. Use 'stdio', 'http', or 'streamable-http'.")
         mcp.run(transport=MCP_TRANSPORT, host=MCP_HOST, port=MCP_PORT)
-    
+
     else:
         raise ValueError(
             f"Unsupported MCP_TRANSPORT={MCP_TRANSPORT!r}. "

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 4
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -1213,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "ros-mcp-server"
-version = "0.2.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 4
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",


### PR DESCRIPTION
This PR introduces HTTP-based and streamable-HTTP transport support for the ROS-MCP server, along with a complete example demonstrating integration with ChatGPT.

Key highlights:

- Added scripts for launching MCP server, tunneling via ngrok, and running ROS (rosbridge + turtlesim).
- Provided a new example and README explaining how to connect ChatGPT Desktop with the MCP server over HTTP.

New Scripts

- scripts/launch_mcp_server.sh: starts the MCP server with http transport protocol on localhost:9000
- scripts/launch_mcp_tunnel.sh: exposes MCP server through ngrok automatically.
- scripts/launch_ros.sh: launches rosbridge and turtlesim with process management.