### PR TITLE
Minor fix to make launch_ros run with all ros2 distros

### DIFF
--- a/scripts/launch_ros.sh
+++ b/scripts/launch_ros.sh
@@ -10,8 +10,8 @@ NC='\033[0m'
 echo -e "${BLUE}Starting ROS 2 environment...${NC}"
 
 # 0. Source ROS 2 environment
-echo -e "${GREEN}[rosjazzy]${NC} Source ROS 2 Jazzy (change according to your distro)..."
-source /opt/ros/jazzy/setup.bash
+echo -e "${GREEN}[ros${ROS_DISTRO}]${NC} Source ROS 2 ${ROS_DISTRO} ..."
+source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # 1. Check if rosbridge is already running
 if pgrep -f rosbridge_websocket > /dev/null; then


### PR DESCRIPTION
As per title:

* Added use of ${ROS_DISTRO} to have the launch_ros bash work with any ros2 distro