### PR TITLE
Fix: support compressed ROS images and clean up server connector

### DIFF
--- a/server.py
+++ b/server.py
@@ -1170,6 +1170,7 @@ def _encode_image_to_imagecontent(image):
     img_obj = Image(data=img_bytes, format="jpeg")
     return img_obj.to_image_content()
 
+
 @mcp.tool(
     description=(
         "First, subscribe to an Image topic using 'subscribe_once' to save an image.\n"
@@ -1179,7 +1180,7 @@ def _encode_image_to_imagecontent(image):
 def analyze_previously_received_image():
     """
     Analyze the previously received image saved at ./camera/received_image.jpeg
-    
+
     This tool loads the previously saved image from './camera/received_image.jpeg'
     (which must have been created by 'parse_image' or 'subscribe_once'), and converts
     it into an MCP-compatible ImageContent format so that the LLM can interpret it.
@@ -1189,9 +1190,6 @@ def analyze_previously_received_image():
         return {"error": "No image found at ./camera/received_image.jpeg"}
     img = PILImage.open(path)
     return _encode_image_to_imagecontent(img)
-
-
-
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -451,7 +451,7 @@ def subscribe_once(
                 ws_manager.send(unsubscribe_msg)
                 if "Image" in msg_type:
                     return {
-                        "message": "Image received successfully and saved in the MCP server. Run the 'analyze_image' tool to analyze it"
+                        "message": "Image received successfully and saved in the MCP server. Run the 'analyze_previously_received_image' tool to analyze it"
                     }
                 else:
                     return {"msg": msg_data.get("msg", {})}
@@ -1154,30 +1154,6 @@ def ping_robot(ip: str, port: int, ping_timeout: float = 2.0, port_timeout: floa
 ##                      IMAGE ANALYSIS
 ##
 ## ############################################################################################## ##
-@mcp.tool(
-    description=(
-        "First, subscribe to an Image topic using 'subscribe_once' to save an image.\n"
-        "Then, use this tool to analyze the saved image\n"
-    )
-)
-def analyze_previously_received_image() -> dict:
-    """
-    Analyze the previously received image saved at ./camera/received_image.jpeg
-    """
-    path = "./camera/received_image.jpeg"
-    if not os.path.exists(path):
-        return {"success": False, "error": "No image found at ./camera/received_image.jpeg"}
-    img = PILImage.open(path)
-    return {
-        "success": True,
-        "image_content": _encode_image_to_imagecontent(img),
-        "vision_instruction": (
-            "Please analyze the provided image and describe the environment, "
-            "people, PPE, objects, and any visible flags."
-        ),
-    }
-
-
 def _encode_image_to_imagecontent(image):
     """
     Encodes a PIL Image to a format compatible with ImageContent.
@@ -1193,6 +1169,29 @@ def _encode_image_to_imagecontent(image):
     img_bytes = buffer.getvalue()
     img_obj = Image(data=img_bytes, format="jpeg")
     return img_obj.to_image_content()
+
+@mcp.tool(
+    description=(
+        "First, subscribe to an Image topic using 'subscribe_once' to save an image.\n"
+        "Then, use this tool to analyze the saved image\n"
+    )
+)
+def analyze_previously_received_image():
+    """
+    Analyze the previously received image saved at ./camera/received_image.jpeg
+    
+    This tool loads the previously saved image from './camera/received_image.jpeg'
+    (which must have been created by 'parse_image' or 'subscribe_once'), and converts
+    it into an MCP-compatible ImageContent format so that the LLM can interpret it.
+    """
+    path = "./camera/received_image.jpeg"
+    if not os.path.exists(path):
+        return {"error": "No image found at ./camera/received_image.jpeg"}
+    img = PILImage.open(path)
+    return _encode_image_to_imagecontent(img)
+
+
+
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -1160,19 +1160,22 @@ def ping_robot(ip: str, port: int, ping_timeout: float = 2.0, port_timeout: floa
         "Then, use this tool to analyze the saved image\n"
     )
 )
-def analyze_previously_received_image():
+def analyze_previously_received_image() -> dict:
     """
-    Analyze the received image.
-
-    This tool loads the previously saved image from './camera/received_image.jpeg'
-    (which must have been created by 'parse_image' or 'subscribe_once'), and converts
-    it into an MCP-compatible ImageContent format so that the LLM can interpret it.
+    Analyze the previously received image saved at ./camera/received_image.jpeg
     """
     path = "./camera/received_image.jpeg"
     if not os.path.exists(path):
-        return {"error": "No previously received image found at ./camera/received_image.jpeg"}
-    image = PILImage.open(path)
-    return _encode_image_to_imagecontent(image)
+        return {"success": False, "error": "No image found at ./camera/received_image.jpeg"}
+    img = PILImage.open(path)
+    return {
+        "success": True,
+        "image_content": _encode_image_to_imagecontent(img),
+        "vision_instruction": (
+            "Please analyze the provided image and describe the environment, "
+            "people, PPE, objects, and any visible flags."
+        ),
+    }
 
 
 def _encode_image_to_imagecontent(image):

--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -32,7 +32,7 @@ def parse_json(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
 
 def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
     """
-    Decode a image message (json with base64 data) and save as PNG.
+    Decode an image message (json with base64 data) and save it as JPEG.
 
     Args:
         raw: JSON string, bytes, or None
@@ -51,18 +51,32 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
         print("[Image] Invalid JSON or missing 'msg' field.")
         return None
 
-    height, width, encoding = msg.get("height"), msg.get("width"), msg.get("encoding")
     data_b64 = msg.get("data")
-
-    if not all([height, width, encoding, data_b64]):
-        print("[Image] Missing required fields in message.")
+    if not data_b64:
+        print("[Image] Missing 'data' field in message.")
         return None
 
-    # Decode base64 to numpy array
+    # ✅ Ensure output directory exists
+    os.makedirs("./camera", exist_ok=True)
+
+    # Case 1: CompressedImage (already JPEG/PNG encoded)
+    if "format" in msg and msg["format"].lower() in ["jpeg", "jpg", "png"]:
+        image_bytes = base64.b64decode(data_b64)
+        path = "./camera/received_image.jpeg"
+        with open(path, "wb") as f:
+            f.write(image_bytes)
+        print(f"[Image] Saved CompressedImage to {path}")
+        return result if isinstance(result, dict) else None
+
+    # Case 2: Raw Image (rgb8, bgr8, mono8)
+    height, width, encoding = msg.get("height"), msg.get("width"), msg.get("encoding")
+    if not all([height, width, encoding]):
+        print("[Image] Missing required fields for raw image.")
+        return None
+
     image_bytes = base64.b64decode(data_b64)
     img_np = np.frombuffer(image_bytes, dtype=np.uint8)
 
-    # Encoding handlers
     try:
         if encoding == "rgb8":
             img_cv = img_np.reshape((height, width, 3))
@@ -78,13 +92,9 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
         print(f"[Image] Reshape error: {e}")
         return None
 
-    if not os.path.exists("./camera"):
-        os.makedirs("./camera")
-
-    success = cv2.imwrite(
-        "./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95]
-    )  # Save as JPEG with quality 95
+    success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
     if success:
+        print("[Image] Saved raw Image to ./camera/received_image.jpeg")
         return result if isinstance(result, dict) else None
     else:
         return None

--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -74,9 +74,11 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
         print("[Image] Missing required fields for raw image.")
         return None
 
+    # Decode base64 to numpy array
     image_bytes = base64.b64decode(data_b64)
     img_np = np.frombuffer(image_bytes, dtype=np.uint8)
 
+    # Encoding handlers
     try:
         if encoding == "rgb8":
             img_cv = img_np.reshape((height, width, 3))
@@ -92,6 +94,7 @@ def parse_image(raw: Optional[Union[str, bytes]]) -> Optional[dict]:
         print(f"[Image] Reshape error: {e}")
         return None
 
+    # Save as JPEG with quality 95
     success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
     if success:
         print("[Image] Saved raw Image to ./camera/received_image.jpeg")


### PR DESCRIPTION
# 🛠️ Changes Made

### server.py
- Added proper imports (`io`, `Image`, `PILImage`) → enabled image encoding for Claude.
- Cleaned duplicate/conflicting vision tools → single analysis path.
- Improved subscribe_once messages → guided capture → analyze flow.
- Standardized _encode_image_to_imagecontent → valid ImageContent.
- Cleaned entry point → stable server startup.

### utils/websocket_manager.py
- Enhanced parse_image:
    - Detects CompressedImage (JPEG/PNG) and base64-decodes directly.
    - Still supports raw sensor_msgs/Image.
- Ensures the ./camera folder exists → prevents missing-folder errors.

# ✅ Why This Change
- Supports both raw and compressed ROS image topics.
- Simplifies server connector and reduces confusion.
- Improves robustness and ensures Claude gets valid image data.

# 🔍 How Tested
- Ran server locally on raw and compressed topics.
- Verified base64 decoding for JPEG/PNG.
- Confirmed ./camera folder auto-created and images saved correctly.
- Claude received valid ImageContent.

# 📌 Notes
- Backward compatible with raw sensor_msgs/Image.
- Adds compressed image support without breaking existing flows.
