### PR TITLE
Add inspect_all_topics + Fix: inspect_all_services and get_service_providers returns empty providers list

### DIFF
--- a/server.py
+++ b/server.py
@@ -367,7 +367,7 @@ def get_subscribers_for_topic(topic: str) -> dict:
 def inspect_all_topics() -> dict:
     """
     Get comprehensive information about all ROS topics including publishers, subscribers, and message types.
-    
+
     Returns:
         dict: Contains detailed information about all topics including:
             - Topic names and message types
@@ -399,7 +399,7 @@ def inspect_all_topics() -> dict:
         for i, topic in enumerate(topics):
             # Get topic type
             topic_type = types[i] if i < len(types) else "unknown"
-            
+
             # Get publishers for this topic
             publishers_message = {
                 "op": "call_service",
@@ -1096,21 +1096,27 @@ def inspect_all_services() -> dict:
             elif type_response and "error" in type_response:
                 service_errors.append(f"Service {service}: {type_response['error']}")
 
-            # Get service providers
-            providers_message = {
+            # Get service provider (using service_node instead of service_providers)
+            provider_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_providers",
-                "type": "rosapi/ServiceProviders",
+                "service": "/rosapi/service_node",
+                "type": "rosapi/ServiceNode",
                 "args": {"service": service},
-                "id": f"get_providers_{service.replace('/', '_')}",
+                "id": f"get_provider_{service.replace('/', '_')}",
             }
 
-            providers_response = ws_manager.request(providers_message)
+            provider_response = ws_manager.request(provider_message)
             providers = []
-            if providers_response and "values" in providers_response:
-                providers = providers_response["values"].get("providers", [])
-            elif providers_response and "error" in providers_response:
-                service_errors.append(f"Service {service} providers: {providers_response['error']}")
+            if provider_response and "values" in provider_response:
+                node = provider_response["values"].get("node", "")
+                if node:
+                    providers = [node]
+            elif provider_response and "result" in provider_response:
+                node = provider_response["result"].get("node", "")
+                if node:
+                    providers = [node]
+            elif provider_response and "error" in provider_response:
+                service_errors.append(f"Service {service} provider: {provider_response['error']}")
 
             service_details[service] = {
                 "type": service_type,

--- a/server.py
+++ b/server.py
@@ -359,6 +359,96 @@ def get_subscribers_for_topic(topic: str) -> dict:
 
 @mcp.tool(
     description=(
+        "Get comprehensive information about all ROS topics including publishers, subscribers, and message types.\n"
+        "Example:\n"
+        "inspect_all_topics()"
+    )
+)
+def inspect_all_topics() -> dict:
+    """
+    Get comprehensive information about all ROS topics including publishers, subscribers, and message types.
+    
+    Returns:
+        dict: Contains detailed information about all topics including:
+            - Topic names and message types
+            - Publishers for each topic
+            - Subscribers for each topic
+            - Connection counts and statistics
+    """
+    # First get all topics
+    topics_message = {
+        "op": "call_service",
+        "service": "/rosapi/topics",
+        "type": "rosapi/Topics",
+        "args": {},
+        "id": "inspect_all_topics_request_1",
+    }
+
+    with ws_manager:
+        topics_response = ws_manager.request(topics_message)
+
+        if not topics_response or "values" not in topics_response:
+            return {"error": "Failed to get topics list"}
+
+        topics = topics_response["values"].get("topics", [])
+        types = topics_response["values"].get("types", [])
+        topic_details = {}
+
+        # Get details for each topic
+        topic_errors = []
+        for i, topic in enumerate(topics):
+            # Get topic type
+            topic_type = types[i] if i < len(types) else "unknown"
+            
+            # Get publishers for this topic
+            publishers_message = {
+                "op": "call_service",
+                "service": "/rosapi/publishers",
+                "type": "rosapi/Publishers",
+                "args": {"topic": topic},
+                "id": f"get_publishers_{topic.replace('/', '_')}",
+            }
+
+            publishers_response = ws_manager.request(publishers_message)
+            publishers = []
+            if publishers_response and "values" in publishers_response:
+                publishers = publishers_response["values"].get("publishers", [])
+            elif publishers_response and "error" in publishers_response:
+                topic_errors.append(f"Topic {topic} publishers: {publishers_response['error']}")
+
+            # Get subscribers for this topic
+            subscribers_message = {
+                "op": "call_service",
+                "service": "/rosapi/subscribers",
+                "type": "rosapi/Subscribers",
+                "args": {"topic": topic},
+                "id": f"get_subscribers_{topic.replace('/', '_')}",
+            }
+
+            subscribers_response = ws_manager.request(subscribers_message)
+            subscribers = []
+            if subscribers_response and "values" in subscribers_response:
+                subscribers = subscribers_response["values"].get("subscribers", [])
+            elif subscribers_response and "error" in subscribers_response:
+                topic_errors.append(f"Topic {topic} subscribers: {subscribers_response['error']}")
+
+            topic_details[topic] = {
+                "type": topic_type,
+                "publishers": publishers,
+                "subscribers": subscribers,
+                "publisher_count": len(publishers),
+                "subscriber_count": len(subscribers),
+            }
+
+        return {
+            "total_topics": len(topics),
+            "topics": topic_details,
+            "topic_errors": topic_errors,  # Include any errors encountered during inspection
+        }
+
+
+@mcp.tool(
+    description=(
         "Subscribe to a ROS topic and return the first message received.\n"
         "Example:\n"
         "subscribe_once(topic='/cmd_vel', msg_type='geometry_msgs/msg/TwistStamped')\n"

--- a/server.py
+++ b/server.py
@@ -1038,7 +1038,7 @@ def get_service_providers(service: str) -> dict:
 
     # Return service providers if present (using same logic as inspect_all_services)
     providers = []
-    
+
     # Handle different response formats safely
     if response and isinstance(response, dict):
         if "values" in response:
@@ -1124,7 +1124,7 @@ def inspect_all_services() -> dict:
 
             provider_response = ws_manager.request(provider_message)
             providers = []
-            
+
             # Handle different response formats safely
             if provider_response and isinstance(provider_response, dict):
                 if "values" in provider_response:
@@ -1136,7 +1136,9 @@ def inspect_all_services() -> dict:
                     if node:
                         providers = [node]
                 elif "error" in provider_response:
-                    service_errors.append(f"Service {service} provider: {provider_response['error']}")
+                    service_errors.append(
+                        f"Service {service} provider: {provider_response['error']}"
+                    )
             elif provider_response is False:
                 service_errors.append(f"Service {service} provider: No response received")
             elif provider_response is True:

--- a/server.py
+++ b/server.py
@@ -359,7 +359,7 @@ def get_subscribers_for_topic(topic: str) -> dict:
 
 @mcp.tool(
     description=(
-        "Get comprehensive information about all ROS topics including publishers, subscribers, and message types.\n"
+        "Get comprehensive information about all ROS topics including publishers, subscribers, and message types. Note that this may take time to execute when three are a large number of topics since it queries each one by one under the hood. \n"
         "Example:\n"
         "inspect_all_topics()"
     )

--- a/server.py
+++ b/server.py
@@ -1038,12 +1038,23 @@ def get_service_providers(service: str) -> dict:
 
     # Return service providers if present (using same logic as inspect_all_services)
     providers = []
-    if response and "result" in response:
-        node = response["result"].get("node", "")
-        if node:
-            providers = [node]
-    elif response and "error" in response:
-        return {"error": f"Service call failed: {response['error']}"}
+    
+    # Handle different response formats safely
+    if response and isinstance(response, dict):
+        if "values" in response:
+            node = response["values"].get("node", "")
+            if node:
+                providers = [node]
+        elif "result" in response:
+            node = response["result"].get("node", "")
+            if node:
+                providers = [node]
+        elif "error" in response:
+            return {"error": f"Service call failed: {response['error']}"}
+    elif response is False:
+        return {"error": f"No response received for service {service}"}
+    elif response is True:
+        return {"error": f"Unexpected boolean response for service {service}"}
     else:
         return {"error": f"Failed to get providers for service {service}"}
 
@@ -1113,13 +1124,23 @@ def inspect_all_services() -> dict:
 
             provider_response = ws_manager.request(provider_message)
             providers = []
-
-            if provider_response and "result" in provider_response:
-                node = provider_response["result"].get("node", "")
-                if node:
-                    providers = [node]
-            elif provider_response and "error" in provider_response:
-                service_errors.append(f"Service {service} provider: {provider_response['error']}")
+            
+            # Handle different response formats safely
+            if provider_response and isinstance(provider_response, dict):
+                if "values" in provider_response:
+                    node = provider_response["values"].get("node", "")
+                    if node:
+                        providers = [node]
+                elif "result" in provider_response:
+                    node = provider_response["result"].get("node", "")
+                    if node:
+                        providers = [node]
+                elif "error" in provider_response:
+                    service_errors.append(f"Service {service} provider: {provider_response['error']}")
+            elif provider_response is False:
+                service_errors.append(f"Service {service} provider: No response received")
+            elif provider_response is True:
+                service_errors.append(f"Service {service} provider: Unexpected boolean response")
 
             service_details[service] = {
                 "type": service_type,

--- a/server.py
+++ b/server.py
@@ -1023,11 +1023,11 @@ def get_service_providers(service: str) -> dict:
     if not service or not service.strip():
         return {"error": "Service name cannot be empty"}
 
-    # rosbridge service call to get service providers
+    # rosbridge service call to get service providers (using service_node like inspect_all_services)
     message = {
         "op": "call_service",
-        "service": "/rosapi/service_providers",
-        "type": "rosapi/ServiceProviders",
+        "service": "/rosapi/service_node",
+        "type": "rosapi/ServiceNode",
         "args": {"service": service},
         "id": f"get_service_providers_request_{service.replace('/', '_')}",
     }
@@ -1036,12 +1036,18 @@ def get_service_providers(service: str) -> dict:
     with ws_manager:
         response = ws_manager.request(message)
 
-    # Return service providers if present
-    if response and "values" in response:
-        providers = response["values"].get("providers", [])
-        return {"service": service, "providers": providers, "provider_count": len(providers)}
+    # Return service providers if present (using same logic as inspect_all_services)
+    providers = []
+    if response and "result" in response:
+        node = response["result"].get("node", "")
+        if node:
+            providers = [node]
+    elif response and "error" in response:
+        return {"error": f"Service call failed: {response['error']}"}
     else:
         return {"error": f"Failed to get providers for service {service}"}
+
+    return {"service": service, "providers": providers, "provider_count": len(providers)}
 
 
 @mcp.tool(
@@ -1107,11 +1113,8 @@ def inspect_all_services() -> dict:
 
             provider_response = ws_manager.request(provider_message)
             providers = []
-            if provider_response and "values" in provider_response:
-                node = provider_response["values"].get("node", "")
-                if node:
-                    providers = [node]
-            elif provider_response and "result" in provider_response:
+
+            if provider_response and "result" in provider_response:
                 node = provider_response["result"].get("node", "")
                 if node:
                     providers = [node]

--- a/server.py
+++ b/server.py
@@ -1063,7 +1063,7 @@ def get_service_providers(service: str) -> dict:
 
 @mcp.tool(
     description=(
-        "Get comprehensive information about all services including types and providers. Note that this may take time to execute when three are a large number of services since it queries each one by one under the hood. \n"        
+        "Get comprehensive information about all services including types and providers. Note that this may take time to execute when three are a large number of services since it queries each one by one under the hood. \n"
         "Example:\n"
         "inspect_all_services()"
     )

--- a/server.py
+++ b/server.py
@@ -1063,7 +1063,7 @@ def get_service_providers(service: str) -> dict:
 
 @mcp.tool(
     description=(
-        "Get comprehensive information about all services including types and providers.\n"
+        "Get comprehensive information about all services including types and providers. Note that this may take time to execute when three are a large number of services since it queries each one by one under the hood. \n"        
         "Example:\n"
         "inspect_all_services()"
     )


### PR DESCRIPTION
This PR adds the `inspect_all_topics` function and fixes `inspect_all_services` + `get_service_providers` to properly show service providers (in this context nodes).

## Problem Fixed
- The `inspect_all_services` and `get_service_providers` function was showing empty providers ("providers": []) for all services because it was using the broken /rosapi/service_providers service.
- No function to inspect topics

## Solution
- Replaced `/rosapi/service_providers` with `/rosapi/service_node` and updated the response parsing to handle the correct format.
- Added `inspect_all_topics` function to inspect topics too.

## Ready for Review ✅