### PR TITLE
Add node-related functionalities

### DIFF
--- a/server.py
+++ b/server.py
@@ -1232,6 +1232,86 @@ def get_node_details(node: str) -> dict:
     return result
 
 
+@mcp.tool(
+    description=(
+        "Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.\n"
+        "Example:\n"
+        "inspect_all_nodes()"
+    )
+)
+def inspect_all_nodes() -> dict:
+    """
+    Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.
+    
+    Returns:
+        dict: Contains detailed information about all nodes including:
+            - Node names and details
+            - Publishers for each node
+            - Subscribers for each node
+            - Services provided by each node
+            - Connection counts and statistics
+    """
+    # First get all nodes
+    nodes_message = {
+        "op": "call_service",
+        "service": "/rosapi/nodes",
+        "type": "rosapi/Nodes",
+        "args": {},
+        "id": "inspect_all_nodes_request_1",
+    }
+
+    with ws_manager:
+        nodes_response = ws_manager.request(nodes_message)
+
+        if not nodes_response or "values" not in nodes_response:
+            return {"error": "Failed to get nodes list"}
+
+        nodes = nodes_response["values"].get("nodes", [])
+        node_details = {}
+
+        # Get details for each node
+        node_errors = []
+        for node in nodes:
+            # Get node details (publishers, subscribers, services)
+            node_details_message = {
+                "op": "call_service",
+                "service": "/rosapi/node_details",
+                "type": "rosapi/NodeDetails",
+                "args": {"node": node},
+                "id": f"get_node_details_{node.replace('/', '_')}",
+            }
+
+            node_details_response = ws_manager.request(node_details_message)
+            
+            if node_details_response and "values" in node_details_response:
+                values = node_details_response["values"]
+                # Extract publishers, subscribers, and services from the response
+                # Note: rosapi uses "publishing" and "subscribing" field names
+                publishers = values.get("publishing", [])
+                subscribers = values.get("subscribing", [])
+                services = values.get("services", [])
+
+                node_details[node] = {
+                    "publishers": publishers,
+                    "subscribers": subscribers,
+                    "services": services,
+                    "publisher_count": len(publishers),
+                    "subscriber_count": len(subscribers),
+                    "service_count": len(services),
+                }
+            elif node_details_response and "result" in node_details_response and not node_details_response["result"]:
+                error_msg = node_details_response.get("values", {}).get("message", "Service call failed")
+                node_errors.append(f"Node {node}: {error_msg}")
+            else:
+                node_errors.append(f"Node {node}: Failed to get node details")
+
+        return {
+            "total_nodes": len(nodes),
+            "nodes": node_details,
+            "node_errors": node_errors,  # Include any errors encountered during inspection
+        }
+
+
 ## ############################################################################################## ##
 ##
 ##                       NETWORK DIAGNOSTICS

--- a/server.py
+++ b/server.py
@@ -1238,7 +1238,7 @@ def get_node_details(node: str) -> dict:
 def inspect_all_nodes() -> dict:
     """
     Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.
-    
+
     Returns:
         dict: Contains detailed information about all nodes including:
             - Node names and details
@@ -1278,7 +1278,7 @@ def inspect_all_nodes() -> dict:
             }
 
             node_details_response = ws_manager.request(node_details_message)
-            
+
             if node_details_response and "values" in node_details_response:
                 values = node_details_response["values"]
                 # Extract publishers, subscribers, and services from the response
@@ -1295,8 +1295,14 @@ def inspect_all_nodes() -> dict:
                     "subscriber_count": len(subscribers),
                     "service_count": len(services),
                 }
-            elif node_details_response and "result" in node_details_response and not node_details_response["result"]:
-                error_msg = node_details_response.get("values", {}).get("message", "Service call failed")
+            elif (
+                node_details_response
+                and "result" in node_details_response
+                and not node_details_response["result"]
+            ):
+                error_msg = node_details_response.get("values", {}).get(
+                    "message", "Service call failed"
+                )
                 node_errors.append(f"Node {node}: {error_msg}")
             else:
                 node_errors.append(f"Node {node}: Failed to get node details")

--- a/server.py
+++ b/server.py
@@ -1242,7 +1242,7 @@ def get_node_details(node: str) -> dict:
 def inspect_all_nodes() -> dict:
     """
     Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.
-    
+
     Returns:
         dict: Contains detailed information about all nodes including:
             - Node names and details
@@ -1282,7 +1282,7 @@ def inspect_all_nodes() -> dict:
             }
 
             node_details_response = ws_manager.request(node_details_message)
-            
+
             if node_details_response and "values" in node_details_response:
                 values = node_details_response["values"]
                 # Extract publishers, subscribers, and services from the response
@@ -1299,8 +1299,14 @@ def inspect_all_nodes() -> dict:
                     "subscriber_count": len(subscribers),
                     "service_count": len(services),
                 }
-            elif node_details_response and "result" in node_details_response and not node_details_response["result"]:
-                error_msg = node_details_response.get("values", {}).get("message", "Service call failed")
+            elif (
+                node_details_response
+                and "result" in node_details_response
+                and not node_details_response["result"]
+            ):
+                error_msg = node_details_response.get("values", {}).get(
+                    "message", "Service call failed"
+                )
                 node_errors.append(f"Node {node}: {error_msg}")
             else:
                 node_errors.append(f"Node {node}: Failed to get node details")

--- a/server.py
+++ b/server.py
@@ -99,6 +99,10 @@ def connect_to_robot(
     actual_ip = ip if ip is not None else "127.0.0.1"
     actual_port = int(port) if port is not None else 9090
 
+    # Fix truncated IP addresses (MCP sometimes truncates "127.0.0.1" to "127")
+    if actual_ip == "127":
+        actual_ip = "127.0.0.1"
+
     # Set the IP and port
     ws_manager.set_ip(actual_ip, actual_port)
 
@@ -1116,6 +1120,116 @@ def call_service(
             "success": False,
             "error": "No response received from service call",
         }
+
+
+@mcp.tool(description=("Get list of all currently running ROS nodes.\nExample:\nget_nodes()"))
+def get_nodes() -> dict:
+    """
+    Get list of all currently running ROS nodes.
+
+    Returns:
+        dict: Contains list of all active nodes,
+            or a message string if no nodes are found.
+    """
+    # rosbridge service call to get node list
+    message = {
+        "op": "call_service",
+        "service": "/rosapi/nodes",
+        "type": "rosapi/Nodes",
+        "args": {},
+        "id": "get_nodes_request_1",
+    }
+
+    # Request node list from rosbridge
+    with ws_manager:
+        response = ws_manager.request(message)
+
+    # Check for service response errors first
+    if response and "result" in response and not response["result"]:
+        # Service call failed - return error with details from values
+        error_msg = response.get("values", {}).get("message", "Service call failed")
+        return {"error": f"Service call failed: {error_msg}"}
+
+    # Return node info if present
+    if response and "values" in response:
+        nodes = response["values"].get("nodes", [])
+        return {"nodes": nodes, "node_count": len(nodes)}
+    else:
+        return {"warning": "No nodes found"}
+
+
+@mcp.tool(
+    description=(
+        "Get detailed information about a specific node including its publishers, subscribers, and services.\n"
+        "Example:\n"
+        "get_node_details('/turtlesim')"
+    )
+)
+def get_node_details(node: str) -> dict:
+    """
+    Get detailed information about a specific node including its publishers, subscribers, and services.
+
+    Args:
+        node (str): The node name (e.g., '/turtlesim')
+
+    Returns:
+        dict: Contains detailed node information including publishers, subscribers, and services,
+            or an error message if node doesn't exist.
+    """
+    # Validate input
+    if not node or not node.strip():
+        return {"error": "Node name cannot be empty"}
+
+    result = {
+        "node": node,
+        "publishers": [],
+        "subscribers": [],
+        "services": [],
+        "publisher_count": 0,
+        "subscriber_count": 0,
+        "service_count": 0,
+    }
+
+    # rosbridge service call to get node details
+    message = {
+        "op": "call_service",
+        "service": "/rosapi/node_details",
+        "type": "rosapi/NodeDetails",
+        "args": {"node": node},
+        "id": f"get_node_details_{node.replace('/', '_')}",
+    }
+
+    # Request node details from rosbridge
+    with ws_manager:
+        response = ws_manager.request(message)
+
+    # Check for service response errors first
+    if response and "result" in response and not response["result"]:
+        # Service call failed - return error with details from values
+        error_msg = response.get("values", {}).get("message", "Service call failed")
+        return {"error": f"Service call failed: {error_msg}"}
+
+    # Extract data from the response
+    if response and "values" in response:
+        values = response["values"]
+        # Extract publishers, subscribers, and services from the response
+        # Note: rosapi uses "publishing" and "subscribing" field names
+        publishers = values.get("publishing", [])
+        subscribers = values.get("subscribing", [])
+        services = values.get("services", [])
+
+        result["publishers"] = publishers
+        result["subscribers"] = subscribers
+        result["services"] = services
+        result["publisher_count"] = len(publishers)
+        result["subscriber_count"] = len(subscribers)
+        result["service_count"] = len(services)
+
+    # Check if we got any data
+    if not result["publishers"] and not result["subscribers"] and not result["services"]:
+        return {"error": f"Node {node} not found or has no details available"}
+
+    return result
 
 
 ## ############################################################################################## ##

--- a/server.py
+++ b/server.py
@@ -99,10 +99,6 @@ def connect_to_robot(
     actual_ip = ip if ip is not None else "127.0.0.1"
     actual_port = int(port) if port is not None else 9090
 
-    # Fix truncated IP addresses (MCP sometimes truncates "127.0.0.1" to "127")
-    if actual_ip == "127":
-        actual_ip = "127.0.0.1"
-
     # Set the IP and port
     ws_manager.set_ip(actual_ip, actual_port)
 
@@ -1242,7 +1238,7 @@ def get_node_details(node: str) -> dict:
 def inspect_all_nodes() -> dict:
     """
     Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.
-
+    
     Returns:
         dict: Contains detailed information about all nodes including:
             - Node names and details
@@ -1282,7 +1278,7 @@ def inspect_all_nodes() -> dict:
             }
 
             node_details_response = ws_manager.request(node_details_message)
-
+            
             if node_details_response and "values" in node_details_response:
                 values = node_details_response["values"]
                 # Extract publishers, subscribers, and services from the response
@@ -1299,14 +1295,8 @@ def inspect_all_nodes() -> dict:
                     "subscriber_count": len(subscribers),
                     "service_count": len(services),
                 }
-            elif (
-                node_details_response
-                and "result" in node_details_response
-                and not node_details_response["result"]
-            ):
-                error_msg = node_details_response.get("values", {}).get(
-                    "message", "Service call failed"
-                )
+            elif node_details_response and "result" in node_details_response and not node_details_response["result"]:
+                error_msg = node_details_response.get("values", {}).get("message", "Service call failed")
                 node_errors.append(f"Node {node}: {error_msg}")
             else:
                 node_errors.append(f"Node {node}: Failed to get node details")


### PR DESCRIPTION
This PR implements one new set offunctions following the established **get/inspect pattern** in the ROS-MCP server. 
Follows issue #103 

### **Problem Solved**
Users cannot inspect or get information about nodes.

### **Solution**
Implemented `get_nodes()`, `get_node_details` and `inspect_all_nodes()` functions that:
- Get all nodes using direct rosbridge calls
- Retrieve detailed information for each node
- Aggregate results with comprehensive statistics
- Handle errors gracefully for individual items

##  **Function Comparison**

| Function | Purpose | Output | Use Case |
|----------|---------|---------|----------|
| `get_nodes()` | **Basic listing** | Simple node names + count | Quick overview, node discovery |
| `get_node_details()` | **Deep analysis for one node** | Simple node name + details | Deep overview of one node |
| `inspect_all_nodes()` | **Comprehensive analysis** | Detailed node info + publishers/subscribers/services | System analysis, debugging, monitoring |

##  **Implementation Details**

### **`inspect_all_nodes()` Function**
```python
@mcp.tool(
    description=(
        "Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.\n"
        "Example:\n"
        "inspect_all_nodes()"
    )
)
def inspect_all_nodes() -> dict:
```

**Features:**
- Gets all nodes using `/rosapi/nodes`
- For each node: gets details via `/rosapi/node_details`
- Extracts publishers, subscribers, and services
- Returns comprehensive node analysis with connection counts

##  **Expected Output Formats**

### **`inspect_all_nodes()` Output:**
```json
{
  "total_nodes": 3,
  "nodes": {
    "/turtlesim": {
      "publishers": ["/parameter_events", "/rosout", "/turtle1/color_sensor", "/turtle1/pose"],
      "subscribers": ["/parameter_events", "/turtle1/cmd_vel"],
      "services": ["/clear", "/kill", "/reset", "/spawn", "/turtle1/set_pen", ...],
      "publisher_count": 4,
      "subscriber_count": 2,
      "service_count": 14
    }
  },
  "node_errors": []
}
```

### Files Modified
- `server.py` - Added `*_nodes()` functions

##  Complete Get/Inspect Pattern

This PR completes the comprehensive get/inspect pattern for all major ROS entities:

| Entity | GET Function | INSPECT Function | Status |
|--------|-------------|------------------|---------|
| **Topics** | `get_topics()` | `inspect_all_topics()` | ✅ **Complete** |
| **Services** | `get_services()` | `inspect_all_services()` | ✅ **Complete** |
| **Nodes** | `get_nodes()` | `inspect_all_nodes()` | ✅ **Complete** |

##  Next Steps

- Still missing `parameters` and `actions` support.

## Ready for Review ✅

 