### PR TITLE
Add get_time tool for manual latency measurement                                                                                                                                                          

### DIFF
--- a/ros_mcp/tools/connection.py
+++ b/ros_mcp/tools/connection.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Union
 
-from fastmcp import FastMCP, Context
+from fastmcp import Context, FastMCP
 
 from ros_mcp.utils.network_utils import ping_ip_and_port
 from ros_mcp.utils.websocket import WebSocketManager

--- a/ros_mcp/tools/connection.py
+++ b/ros_mcp/tools/connection.py
@@ -1,5 +1,6 @@
 """Connection tools for ROS MCP."""
 
+import time
 from typing import Union
 
 from fastmcp import FastMCP
@@ -82,3 +83,31 @@ def register_connection_tools(
             dict: Contains ping and port check results with detailed status information.
         """
         return ping_ip_and_port(ip, port, ping_timeout, port_timeout)
+
+    @mcp.tool(
+        description=(
+            "Ping the MCP server with a timestamp to measure round-trip latency.\n"
+            "Send a Unix timestamp (in milliseconds) and receive the latency in milliseconds.\n"
+            "Example:\n"
+            "ping_latency(client_timestamp_ms=1705847123456)"
+        )
+    )
+    def ping_latency(client_timestamp_ms: int) -> dict:
+        """
+        Measure round-trip latency to the MCP server.
+
+        Args:
+            client_timestamp_ms (int): Unix timestamp in milliseconds from the client.
+
+        Returns:
+            dict: Contains client timestamp, server timestamp, and calculated latency.
+        """
+        server_timestamp_ms = int(time.time() * 1000)
+        latency_ms = server_timestamp_ms - client_timestamp_ms
+
+        return {
+            "client_timestamp_ms": client_timestamp_ms,
+            "server_timestamp_ms": server_timestamp_ms,
+            "latency_ms": latency_ms,
+            "latency_seconds": latency_ms / 1000.0,
+        }

--- a/ros_mcp/tools/connection.py
+++ b/ros_mcp/tools/connection.py
@@ -104,17 +104,14 @@ def register_connection_tools(
         Returns:
             dict: Contains current UTC time in HH:MM:SS format.
         """
+
         def get_current_time() -> str:
             return datetime.now(timezone.utc).strftime("%H:%M:%S")
 
         if use_progress:
             for i in range(10):
                 current_time = get_current_time()
-                await ctx.report_progress(
-                    progress=i + 1,
-                    total=10,
-                    message=f"UTC: {current_time}"
-                )
+                await ctx.report_progress(progress=i + 1, total=10, message=f"UTC: {current_time}")
                 if i < 9:
                     await asyncio.sleep(1)
 

--- a/ros_mcp/tools/connection.py
+++ b/ros_mcp/tools/connection.py
@@ -1,9 +1,10 @@
 """Connection tools for ROS MCP."""
 
-import time
+import asyncio
+from datetime import datetime, timezone
 from typing import Union
 
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
 
 from ros_mcp.utils.network_utils import ping_ip_and_port
 from ros_mcp.utils.websocket import WebSocketManager
@@ -86,28 +87,38 @@ def register_connection_tools(
 
     @mcp.tool(
         description=(
-            "Ping the MCP server with a timestamp to measure round-trip latency.\n"
-            "Send a Unix timestamp (in milliseconds) and receive the latency in milliseconds.\n"
-            "Example:\n"
-            "ping_latency(client_timestamp_ms=1705847123456)"
+            "Get the current server time in HH:MM:SS format (UTC).\n"
+            "Compare with time.is to measure latency.\n"
+            "If use_progress=True, sends time updates every second for 10 seconds.\n"
+            "If use_progress=False, returns time once."
         )
     )
-    def ping_latency(client_timestamp_ms: int) -> dict:
+    async def get_time(ctx: Context, use_progress: bool = False) -> dict:
         """
-        Measure round-trip latency to the MCP server.
+        Get current server time for latency measurement.
 
         Args:
-            client_timestamp_ms (int): Unix timestamp in milliseconds from the client.
+            ctx: MCP context for progress reporting.
+            use_progress: If True, send 10 seconds of progress updates.
 
         Returns:
-            dict: Contains client timestamp, server timestamp, and calculated latency.
+            dict: Contains current UTC time in HH:MM:SS format.
         """
-        server_timestamp_ms = int(time.time() * 1000)
-        latency_ms = server_timestamp_ms - client_timestamp_ms
+        def get_current_time() -> str:
+            return datetime.now(timezone.utc).strftime("%H:%M:%S")
+
+        if use_progress:
+            for i in range(10):
+                current_time = get_current_time()
+                await ctx.report_progress(
+                    progress=i + 1,
+                    total=10,
+                    message=f"UTC: {current_time}"
+                )
+                if i < 9:
+                    await asyncio.sleep(1)
 
         return {
-            "client_timestamp_ms": client_timestamp_ms,
-            "server_timestamp_ms": server_timestamp_ms,
-            "latency_ms": latency_ms,
-            "latency_seconds": latency_ms / 1000.0,
+            "utc_time": get_current_time(),
+            "compare_with": "https://time.is/UTC",
         }


### PR DESCRIPTION
# Problem
                                                                                                                                                                                                            
LLM clients (Claude, ChatGPT) don't expose timing APIs, making it impossible to programmatically measure MCP round-trip latency from within the protocol.                                                 
                                                                                                                                                                                                            #Solution                                                                                                                                                                                                  
                                                                                                                                                                                                            Added get_time(use_progress) tool that displays server UTC time, allowing users to manually compare with an external time source (e.g., time.is/UTC).                                                     
                                                                                                                                                                                                            #Usage:                                                                                                                                                                                                    
  - get_time() — returns UTC time once                                                                                                                                                                      
  - get_time(use_progress=True) — streams time every second for 10 seconds via context progress updates                                                                                                             
                                                                                                                                                                                                            
  How to measure latency:                                                                                                                                                                                   
  1. Open https://time.is/UTC                                                                                                                                                                               
  2. Call get_time(use_progress=True)                                                                                                                                                                       
  3. Compare displayed times — the difference ≈ your latency         
  
  # Ready for Review