### PR TITLE
docs: add warning and termination commands to prevent Claude config reset

### DIFF
--- a/docs/install/clients/claude-desktop.md
+++ b/docs/install/clients/claude-desktop.md
@@ -17,6 +17,12 @@ See the [uv installation docs](https://docs.astral.sh/uv/getting-started/install
 
 ## 2. Add the MCP Server
 
+> ⚠️ **Important**: Quit Claude Desktop **completely** before editing `claude_desktop_config.json`. If the app is running in the background when you save the file, your changes can be silently overwritten the moment you enter a chat. Terminate the process first:
+>
+> - **Linux:** `pkill -f claude-desktop`
+> - **macOS:** Right-click the dock icon → Quit, or `pkill -f -i claude` in Terminal
+> - **Windows:** End the `Claude` task in Task Manager (Ctrl+Shift+Esc → find *Claude* → End task)
+
 Locate and edit the `claude_desktop_config.json` file (create it if it doesn't exist):
 
 | OS | Config file path |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,6 +55,11 @@ uvx ros-mcp --help
 - Follow the installation instructions from the community-supported [claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian)
 
 ### 2.2 Configure
+⚠️ **Important**: Always completely quit Claude Desktop **before** editing claude_desktop_config.json`. If you edit the config while Claude Desktop is running in the background, your changes may be silently overwritten when you enter the chat window.
+- Completely terminate Claude Desktop processes
+```bash
+  pkill -f claude-desktop
+``` 
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
@@ -99,6 +104,8 @@ killall claude-desktop
 claude-desktop
 ```
 
+- If the `ros-mcp-server` doesn't appear even after correctly configuring `claude_desktop_config.json`, this could be a Claude Desktop caching issue. Try the complete shutdown and restart process above.
+
 </details>
 
 </details>
@@ -129,6 +136,11 @@ uvx ros-mcp --help
 - Download from [claude.ai](https://claude.ai/download)
 
 ### 2.2 Configure
+⚠️ **Important**: Always completely quit Claude Desktop **before** editing claude_desktop_config.json`. If you edit the config while Claude Desktop is running in the background, your changes may be silently overwritten when you enter the chat window.
+- Completely terminate Claude Desktop processes
+```bash
+  pkill -f claude-desktop
+``` 
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
@@ -173,6 +185,8 @@ killall claude-desktop
 claude-desktop
 ```
 
+- If the `ros-mcp-server` doesn't appear even after correctly configuring `claude_desktop_config.json`, this could be a Claude Desktop caching issue. Try the complete shutdown and restart process above.
+
 </details>
 
 </details>
@@ -205,6 +219,11 @@ uvx ros-mcp --help
 This will have Claude running on Windows and the MCP server running on WSL. We assume that you have installed uv on your [WSL](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-US&gl=US)
 
 ### 2.2 Configure
+⚠️ **Important**: Always completely quit Claude Desktop **before** editing claude_desktop_config.json`. If you edit the config while Claude Desktop is running in the background, your changes may be silently overwritten when you enter the chat window.
+- Completely terminate Claude Desktop processes
+```bash
+  pkill -f claude-desktop
+``` 
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
@@ -254,6 +273,8 @@ killall claude-desktop
 claude-desktop
 ```
 
+- If the `ros-mcp-server` doesn't appear even after correctly configuring `claude_desktop_config.json`, this could be a Claude Desktop caching issue. Try the complete shutdown and restart process above.
+
 </details>
 
 </details>
@@ -287,6 +308,11 @@ uvx ros-mcp --help
 This will have Claude and the MCP server running within Windows.
 
 ### 2.2 Configure
+⚠️ **Important**: Always completely quit Claude Desktop **before** editing claude_desktop_config.json`. If you edit the config while Claude Desktop is running in the background, your changes may be silently overwritten when you enter the chat window.
+- Completely terminate Claude Desktop processes
+```bash
+  pkill -f claude-desktop
+``` 
 - Locate and edit the `claude_desktop_config.json` file:
 - (If the file does not exist, create it)
 ```bash
@@ -327,6 +353,8 @@ killall claude-desktop
 # Restart Claude Desktop
 claude-desktop
 ```
+
+- If the `ros-mcp-server` doesn't appear even after correctly configuring `claude_desktop_config.json`, this could be a Claude Desktop caching issue. Try the complete shutdown and restart process above.
 
 </details>
 


### PR DESCRIPTION
### Description
This PR updates the Claude Desktop setup guide to add a crucial warning regarding the configuration step.

Currently, if a user modifies `claude_desktop_config.json` while Claude Desktop is still running in the background, the configuration fails silently and gets wiped/reset the moment they enter the chat window.

To prevent users from wasting time debugging their MCP server or ROS connections, this PR adds explicit instructions to completely terminate the background process before editing the config, plus troubleshooting for caching issues.

### Changes Made
- Added a ⚠️ Important warning note in `docs/install/clients/claude-desktop.md` explaining the silent overwrite behavior 
- Added platform-specific termination commands:
  - Linux/macOS: `pkill -f claude-desktop`
  - Windows: Task Manager instructions
- Added caching troubleshooting note in the "Verify the Setup" section

### Platform Note
I originally encountered and reproduced this silent reset issue on Windows 11 (Claude v1.1.9493.0). This PR now includes explicit termination instructions for all platforms (Linux/macOS/Windows).

### Related Issue
Resolves #291
