### PR TITLE
fix: make image save path platform-independent

### DIFF
--- a/ros_mcp/tools/images.py
+++ b/ros_mcp/tools/images.py
@@ -8,6 +8,8 @@ from fastmcp.utilities.types import Image
 from mcp.types import ImageContent, ToolAnnotations
 from PIL import Image as PILImage
 
+from ros_mcp.utils.paths import get_fixed_image_path
+
 
 def convert_expects_image_hint(expects_image: str) -> bool | None:
     """
@@ -68,7 +70,7 @@ def register_image_tools(
         ),
     )
     def view_saved_image(
-        image_path: str = "./camera/received_image.jpeg",
+        image_path: str = "",
     ) -> ImageContent:  # type: ignore  # See issue #140
         """
         View a previously saved image from the specified path.
@@ -78,11 +80,19 @@ def register_image_tools(
         re-view a saved image without re-subscribing.
 
         Args:
-            image_path (str): Path to the saved image file (default: "./camera/received_image.jpeg")
+            image_path (str): Optional custom path to the image file. If not provided,
+                            uses the default system cache location.
 
         Returns:
             ImageContent: JPEG-encoded image wrapped in an ImageContent object, or error dict if file not found.
         """
+        # Use default path if not specified
+        if not image_path:
+            try:
+                image_path = str(get_fixed_image_path("received_image.jpeg"))
+            except RuntimeError as e:
+                return {"error": f"Failed to get image path: {e}"}  # type: ignore[return-value]  # See issue #140
+
         if not os.path.exists(image_path):
             return {"error": f"No image found at {image_path}"}  # type: ignore[return-value]  # See issue #140
         img = PILImage.open(image_path)

--- a/ros_mcp/tools/topics.py
+++ b/ros_mcp/tools/topics.py
@@ -10,6 +10,7 @@ from mcp.types import TextContent, ToolAnnotations
 from PIL import Image as PILImage
 
 from ros_mcp.tools.images import _encode_image_to_imagecontent, convert_expects_image_hint
+from ros_mcp.utils.paths import get_fixed_image_path
 from ros_mcp.utils.response import _check_response, _safe_get_values
 from ros_mcp.utils.websocket import WebSocketManager, parse_input
 
@@ -385,7 +386,7 @@ def register_topic_tools(
                     ws_manager.send(unsubscribe_msg)
                     # Return appropriate message based on whether image was actually parsed
                     if was_parsed_as_image:
-                        image_path = "./camera/received_image.jpeg"
+                        image_path = str(get_fixed_image_path("received_image.jpeg"))
                         if os.path.exists(image_path):
                             img = PILImage.open(image_path)
                             image_content = _encode_image_to_imagecontent(img)
@@ -536,7 +537,7 @@ def register_topic_tools(
                     msg_index = len(collected_messages)
                     # Add message based on whether it was actually parsed as image
                     if was_parsed_as_image:
-                        image_path = "./camera/received_image.jpeg"
+                        image_path = str(get_fixed_image_path("received_image.jpeg"))
                         if os.path.exists(image_path):
                             img = PILImage.open(image_path)
                             collected_messages.append(_encode_image_to_imagecontent(img))

--- a/ros_mcp/utils/paths.py
+++ b/ros_mcp/utils/paths.py
@@ -1,0 +1,85 @@
+"""Path utilities for ROS MCP.
+
+This module provides centralized path management for the ROS MCP server,
+including camera directory and image file paths.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+try:
+    from platformdirs import user_cache_dir
+except ImportError:
+    user_cache_dir = None
+
+
+def get_camera_dir() -> Path:
+    """
+    Get the camera directory path.
+
+    The directory is determined in the following priority order:
+    1. ROS_MCP_CAMERA_DIR environment variable (if set)
+    2. Platform-specific cache directory (if platformdirs is available)
+       - Linux: ~/.cache/ros-mcp/camera/
+       - macOS: ~/Library/Caches/ros-mcp/camera/
+       - Windows: %LOCALAPPDATA%\\ros-mcp\\camera\\
+    3. System temp directory as fallback
+       - /tmp/ros-mcp/camera/ (Linux/macOS)
+       - %TEMP%\\ros-mcp\\camera\\ (Windows)
+
+    Returns:
+        Path: Absolute path to the camera directory
+
+    Examples:
+        >>> camera_dir = get_camera_dir()
+        >>> print(camera_dir)
+        PosixPath('/home/user/.cache/ros-mcp/camera')
+    """
+    override = os.environ.get("ROS_MCP_CAMERA_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+
+    if user_cache_dir is not None:
+        return Path(user_cache_dir("ros-mcp", appauthor=False)) / "camera"
+
+    return Path(tempfile.gettempdir()) / "ros-mcp" / "camera"
+
+
+def get_fixed_image_path(filename: str = "received_image.jpeg") -> Path:
+    """
+    Get the fixed image path in the camera directory.
+
+    This function ensures the camera directory exists before returning the path.
+    It will create the directory if it doesn't exist.
+
+    Args:
+        filename (str): Name of the image file (default: "received_image.jpeg")
+
+    Returns:
+        Path: Absolute path to the image file
+
+    Raises:
+        RuntimeError: If the camera path exists but is not a directory,
+                     or if directory creation fails
+
+    Examples:
+        >>> image_path = get_fixed_image_path()
+        >>> print(image_path)
+        PosixPath('/home/user/.cache/ros-mcp/camera/received_image.jpeg')
+
+        >>> custom_path = get_fixed_image_path("my_image.jpg")
+        >>> print(custom_path)
+        PosixPath('/home/user/.cache/ros-mcp/camera/my_image.jpg')
+    """
+    camera_dir = get_camera_dir()
+
+    if camera_dir.exists() and not camera_dir.is_dir():
+        raise RuntimeError(f"Camera path exists but is not a directory: {camera_dir}")
+
+    try:
+        camera_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise RuntimeError(f"Failed to create camera directory: {camera_dir}") from e
+
+    return camera_dir / filename

--- a/ros_mcp/utils/websocket.py
+++ b/ros_mcp/utils/websocket.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import os
 import sys
 import threading
 from typing import Union
@@ -8,6 +7,8 @@ from typing import Union
 import cv2
 import numpy as np
 import websocket
+
+from ros_mcp.utils.paths import get_fixed_image_path
 
 
 def parse_json(raw: Union[str, bytes] | None) -> dict | None:
@@ -115,18 +116,15 @@ def parse_image(raw: Union[str, bytes] | None) -> dict | None:
         print("[Image] Missing 'data' field in message.", file=sys.stderr)
         return None
 
-    # 4. Ensure output directory exists
-    os.makedirs("./camera", exist_ok=True)
-
-    # 5. Determine image type and process accordingly
+    # 4. Determine image type and process accordingly
     format = msg.get("format")
     print(f"[Image] Format: {format}", file=sys.stderr)
 
-    # 5a. Handle CompressedImage (already JPEG/PNG encoded)
+    # 4a. Handle CompressedImage (already JPEG/PNG encoded)
     if format and any(fmt in format.lower() for fmt in ["jpeg", "jpg", "png", "bmp", "compressed"]):
         return _handle_compressed_image(data_b64, result)
 
-    # 5b. Handle Raw Image (rgb8, bgr8, mono8, mono16, 16uc1)
+    # 4b. Handle Raw Image (rgb8, bgr8, mono8, mono16, 16uc1)
     height, width, encoding = msg.get("height"), msg.get("width"), msg.get("encoding")
     if not all([height, width, encoding]):
         print("[Image] Missing required fields for raw image.", file=sys.stderr)
@@ -137,7 +135,7 @@ def parse_image(raw: Union[str, bytes] | None) -> dict | None:
 
 def _handle_compressed_image(data_b64: str, result: dict) -> dict | None:
     """Handle compressed image data (JPEG/PNG already encoded)."""
-    path = "./camera/received_image.jpeg"
+    path = get_fixed_image_path("received_image.jpeg")
     image_bytes = base64.b64decode(data_b64)
 
     with open(path, "wb") as f:
@@ -170,11 +168,13 @@ def _handle_raw_image(
         return None
 
     # Save as JPEG with quality 95
-    success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
+    path = get_fixed_image_path("received_image.jpeg")
+    success = cv2.imwrite(str(path), img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
     if success:
-        print("[Image] Saved raw Image to ./camera/received_image.jpeg", file=sys.stderr)
+        print(f"[Image] Saved raw Image to {path}", file=sys.stderr)
         return result if isinstance(result, dict) else None
     else:
+        print(f"[Image] cv2.imwrite failed for {path}", file=sys.stderr)
         return None
 
 


### PR DESCRIPTION
### Summary
Fix image saving failure in `uvx` execution caused by CWD-dependent relative path (`./camera`).

### Problem
Running:
```bash
uvx ros-mcp --transport=stdio
```
results in:
```bash
Permission denied: './camera'
```
But local execution works:
```bash
cd ~/ros-mcp-server && uv run server.py --transport=stdio
```

### Root Cause

Image saving relied on a relative path:

./camera/received_image.jpeg

This depends on the current working directory (CWD), which differs between:
 - local execution
 - packaged (uvx) execution
 - MCP client runtime
 
As a result, the same relative path may resolve to different filesystem locations depending on how the server is launched. In packaged or client-managed execution, it can point to a directory that does not exist or is not writable, which leads to errors such as:

Permission denied: './camera'

### Solution
 - Replace relative path with platform-independent path
 - Add centralized path utility (get_fixed_image_path)

### Support:
 - ROS_MCP_CAMERA_DIR override
 - OS cache directory (platformdirs)
 - temp fallback

### Changes
 - Remove ./camera usage
 - Add ros_mcp/utils/paths.py
 - Update image handlers to use get_fixed_image_path()

### Result
 - Fixes permission error in uvx
 - Ensures image paths always resolve to a writable location
 - Consistent behavior across all execution modes

### Testing
Tested using a locally built package via uv to simulate packaged execution.

```json
"ros-mcp-prod-check": {
  "command": "wsl",
  "args": [
    "-d", "Ubuntu",
    "bash", "-lc",
    "uvx --from /home/hyuntaek/ros-mcp-server/dist/ros_mcp-3.0.1.tar.gz ros-mcp --transport=stdio"
  ]
}
```
### Verified:
 - error reproduced before fix
 - resolved after fix
 - image decode/save/analysis all working

### Related
Closes #301
