### PR TITLE
refactor(actions): standardize action tools, add integration tests (step5)

### DIFF
--- a/ros_mcp/tools/actions.py
+++ b/ros_mcp/tools/actions.py
@@ -126,31 +126,44 @@ def register_action_tools(
         if not action or not action.strip():
             return {"error": "Action name cannot be empty"}
 
-        if not action_type or not action_type.strip():
-            # List available action types so the caller can provide one
-            interfaces_message = {
-                "op": "call_service",
-                "service": rosapi_service("interfaces"),
-                "type": rosapi_type("Interfaces"),
-                "args": {},
-                "id": f"get_interfaces_for_{action.replace('/', '_')}",
-            }
-            with ws_manager:
-                interfaces_response = ws_manager.request(interfaces_message)
-
-            available = []
-            iface_values = _safe_get_values(interfaces_response)
-            if iface_values is not None:
-                available = [i for i in iface_values.get("interfaces", []) if "/action/" in i]
-
-            return {
-                "error": f"action_type is required for {action}",
-                "action": action,
-                "available_action_types": available,
-            }
-
-        # Fetch goal, result, and feedback structures
         with ws_manager:
+            # Fetch the available action interfaces. We need them to suggest a
+            # type when none was given, and to validate a supplied type before
+            # querying its details: asking rosapi for the goal/result/feedback
+            # of a non-existent type crashes the ROS 2 rosapi node, taking down
+            # all rosapi services.
+            interfaces_response = ws_manager.request(
+                {
+                    "op": "call_service",
+                    "service": rosapi_service("interfaces"),
+                    "type": rosapi_type("Interfaces"),
+                    "args": {},
+                    "id": f"get_interfaces_for_{action.replace('/', '_')}",
+                }
+            )
+            iface_values = _safe_get_values(interfaces_response)
+            available = (
+                [i for i in iface_values.get("interfaces", []) if "/action/" in i]
+                if iface_values is not None
+                else []
+            )
+
+            if not action_type or not action_type.strip():
+                return {
+                    "error": f"action_type is required for {action}",
+                    "action": action,
+                    "available_action_types": available,
+                }
+
+            if action_type not in available:
+                return {
+                    "error": f"Action type '{action_type}' not found",
+                    "action": action,
+                    "action_type": action_type,
+                    "available_action_types": available,
+                }
+
+            # Fetch goal, result, and feedback structures
             parts = {
                 part: _fetch_action_part(ws_manager, action_type, part) for part in _ACTION_PARTS
             }

--- a/ros_mcp/tools/actions.py
+++ b/ros_mcp/tools/actions.py
@@ -1,6 +1,5 @@
 """Action tools for ROS MCP."""
 
-import asyncio
 import json
 import time
 import uuid
@@ -9,6 +8,7 @@ from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
 from ros_mcp.utils.response import _safe_get_values
+from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager
 
 
@@ -36,14 +36,14 @@ def register_action_tools(
                 or a message string if no actions are found.
         """
         # Check if required service is available
-        required_services = ["/rosapi/action_servers"]
+        required_services = [rosapi_service("action_servers")]
 
         with ws_manager:
             # Get available services to check compatibility
             services_message = {
                 "op": "call_service",
-                "service": "/rosapi/services",
-                "type": "rosapi/Services",
+                "service": rosapi_service("services"),
+                "type": rosapi_type("Services"),
                 "args": {},
                 "id": "check_services_for_get_actions",
             }
@@ -78,8 +78,8 @@ def register_action_tools(
         # rosbridge service call to get action list
         message = {
             "op": "call_service",
-            "service": "/rosapi/action_servers",
-            "type": "rosapi/ActionServers",
+            "service": rosapi_service("action_servers"),
+            "type": rosapi_type("ActionServers"),
             "args": {},
             "id": "get_actions_request_1",
         }
@@ -137,14 +137,14 @@ def register_action_tools(
         action_interfaces = []  # Initialize before if/else block
 
         # Check if required service is available
-        required_services = ["/rosapi/interfaces"]
+        required_services = [rosapi_service("interfaces")]
 
         with ws_manager:
             # Get available services to check compatibility
             services_message = {
                 "op": "call_service",
-                "service": "/rosapi/services",
-                "type": "rosapi/Services",
+                "service": rosapi_service("services"),
+                "type": rosapi_type("Services"),
                 "args": {},
                 "id": "check_services_for_get_action_type",
             }
@@ -191,8 +191,8 @@ def register_action_tools(
             # For unknown actions, try to derive the type from interfaces list
             interfaces_message = {
                 "op": "call_service",
-                "service": "/rosapi/interfaces",
-                "type": "rosapi/Interfaces",
+                "service": rosapi_service("interfaces"),
+                "type": rosapi_type("Interfaces"),
                 "args": {},
                 "id": f"get_interfaces_for_action_{action.replace('/', '_')}",
             }
@@ -231,17 +231,17 @@ def register_action_tools(
 
         # Check if required action detail services are available
         required_detail_services = [
-            "/rosapi/action_goal_details",
-            "/rosapi/action_result_details",
-            "/rosapi/action_feedback_details",
+            rosapi_service("action_goal_details"),
+            rosapi_service("action_result_details"),
+            rosapi_service("action_feedback_details"),
         ]
 
         with ws_manager:
             # Get available services to check compatibility
             services_message = {
                 "op": "call_service",
-                "service": "/rosapi/services",
-                "type": "rosapi/Services",
+                "service": rosapi_service("services"),
+                "type": rosapi_type("Services"),
                 "args": {},
                 "id": "check_services_for_action_details",
             }
@@ -286,8 +286,8 @@ def register_action_tools(
         # Get goal details using action-specific service
         goal_message = {
             "op": "call_service",
-            "service": "/rosapi/action_goal_details",
-            "type": "rosapi_msgs/srv/ActionGoalDetails",
+            "service": rosapi_service("action_goal_details"),
+            "type": rosapi_type("ActionGoalDetails"),
             "args": {"type": action_type},
             "id": f"get_action_goal_details_{action_type.replace('/', '_')}",
         }
@@ -327,8 +327,8 @@ def register_action_tools(
         # Get result details using action-specific service
         result_message = {
             "op": "call_service",
-            "service": "/rosapi/action_result_details",
-            "type": "rosapi_msgs/srv/ActionResultDetails",
+            "service": rosapi_service("action_result_details"),
+            "type": rosapi_type("ActionResultDetails"),
             "args": {"type": action_type},
             "id": f"get_action_result_details_{action_type.replace('/', '_')}",
         }
@@ -368,8 +368,8 @@ def register_action_tools(
         # Get feedback details using action-specific service
         feedback_message = {
             "op": "call_service",
-            "service": "/rosapi/action_feedback_details",
-            "type": "rosapi_msgs/srv/ActionFeedbackDetails",
+            "service": rosapi_service("action_feedback_details"),
+            "type": rosapi_type("ActionFeedbackDetails"),
             "args": {"type": action_type},
             "id": f"get_action_feedback_details_{action_type.replace('/', '_')}",
         }
@@ -659,11 +659,6 @@ def register_action_tools(
 
                     except json.JSONDecodeError:
                         continue
-                else:
-                    # No response received, continue waiting
-                    pass
-
-                await asyncio.sleep(0.1)
 
             # Timeout - return last feedback if available
             if ctx and feedback_count > 0:

--- a/ros_mcp/tools/actions.py
+++ b/ros_mcp/tools/actions.py
@@ -7,9 +7,69 @@ import uuid
 from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
-from ros_mcp.utils.response import _safe_get_values
+from ros_mcp.utils.response import _check_response, _safe_get_values
 from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager
+
+# Action detail parts: result key → (rosapi service name, rosapi type name)
+_ACTION_PARTS = {
+    "goal": ("action_goal_details", "ActionGoalDetails"),
+    "result": ("action_result_details", "ActionResultDetails"),
+    "feedback": ("action_feedback_details", "ActionFeedbackDetails"),
+}
+
+
+def _parse_typedef(typedef: dict) -> dict:
+    """Parse a rosapi typedef into a structured field description."""
+    field_names = typedef.get("fieldnames", [])
+    field_types = typedef.get("fieldtypes", [])
+    field_array_len = typedef.get("fieldarraylen", [])
+    examples = typedef.get("examples", [])
+    const_names = typedef.get("constnames", [])
+    const_values = typedef.get("constvalues", [])
+
+    fields = {}
+    field_details = {}
+    for i, (name, ftype) in enumerate(zip(field_names, field_types)):
+        fields[name] = ftype
+        field_details[name] = {
+            "type": ftype,
+            "array_length": field_array_len[i] if i < len(field_array_len) else -1,
+            "example": examples[i] if i < len(examples) else None,
+        }
+
+    return {
+        "fields": fields,
+        "field_count": len(fields),
+        "field_details": field_details,
+        "message_type": typedef.get("type", ""),
+        "examples": examples,
+        "constants": dict(zip(const_names, const_values)) if const_names else {},
+    }
+
+
+def _fetch_action_part(ws_manager: WebSocketManager, action_type: str, part: str) -> dict:
+    """Fetch one part (goal/result/feedback) of an action definition."""
+    service, type_name = _ACTION_PARTS[part]
+    message = {
+        "op": "call_service",
+        "service": rosapi_service(service),
+        "type": rosapi_type(type_name),
+        "args": {"type": action_type},
+        "id": f"get_action_{part}_{action_type.replace('/', '_')}",
+    }
+    response = ws_manager.request(message)
+
+    error = _check_response(response)
+    if error:
+        return {}
+
+    values = _safe_get_values(response)
+    if values is not None:
+        typedefs = values.get("typedefs", [])
+        if typedefs:
+            return _parse_typedef(typedefs[0])
+    return {}
 
 
 def register_action_tools(
@@ -19,9 +79,7 @@ def register_action_tools(
     """Register all action-related tools."""
 
     @mcp.tool(
-        description=(
-            "Get list of all available ROS actions. Works only with ROS 2.\nExample:\nget_actions()"
-        ),
+        description=("Get list of all available ROS actions.\nExample:\nget_actions()"),
         annotations=ToolAnnotations(
             title="Get Actions",
             readOnlyHint=True,
@@ -29,53 +87,12 @@ def register_action_tools(
     )
     def get_actions() -> dict:
         """
-        Get list of all available ROS actions. Works only with ROS 2.
+        Get list of all available ROS actions.
 
         Returns:
             dict: Contains list of all active actions,
                 or a message string if no actions are found.
         """
-        # Check if required service is available
-        required_services = [rosapi_service("action_servers")]
-
-        with ws_manager:
-            # Get available services to check compatibility
-            services_message = {
-                "op": "call_service",
-                "service": rosapi_service("services"),
-                "type": rosapi_type("Services"),
-                "args": {},
-                "id": "check_services_for_get_actions",
-            }
-
-            services_response = ws_manager.request(services_message)
-            if not services_response or not isinstance(services_response, dict):
-                return {
-                    "warning": "Cannot check service availability",
-                    "compatibility": {
-                        "issue": "Cannot determine available services",
-                        "required_services": required_services,
-                        "suggestion": "Ensure rosbridge is running and rosapi is available",
-                    },
-                }
-
-            svc_values = _safe_get_values(services_response)
-            available_services = svc_values.get("services", []) if svc_values else []
-            missing_services = [svc for svc in required_services if svc not in available_services]
-
-            if missing_services:
-                return {
-                    "warning": "Action listing not supported by this rosbridge/rosapi version",
-                    "compatibility": {
-                        "issue": "Required action services are not available",
-                        "missing_services": missing_services,
-                        "required_services": required_services,
-                        "available_services": [s for s in available_services if "action" in s],
-                        "suggestion": "This rosbridge version doesn't support action listing services",
-                    },
-                }
-
-        # rosbridge service call to get action list
         message = {
             "op": "call_service",
             "service": rosapi_service("action_servers"),
@@ -84,33 +101,22 @@ def register_action_tools(
             "id": "get_actions_request_1",
         }
 
-        # Request action list from rosbridge
         with ws_manager:
             response = ws_manager.request(message)
 
-        # Handle error responses from ws_manager
-        if response and "error" in response:
-            return {"error": f"WebSocket error: {response['error']}"}
+        error = _check_response(response)
+        if error:
+            return error
 
-        # Check for service response errors first
-        if response and "result" in response and not response["result"]:
-            # Service call failed - return error with details from values
-            if "values" in response and isinstance(response["values"], dict):
-                error_msg = response["values"].get("message", "Service call failed")
-            else:
-                error_msg = "Service call failed"
-            return {"error": f"Service call failed: {error_msg}"}
-
-        # Return action info if present
         values = _safe_get_values(response)
         if values is not None:
             actions = values.get("action_servers", [])
             return {"actions": actions, "action_count": len(actions)}
-        return {"warning": "No actions found or /rosapi/action_servers service not available"}
+        return {"warning": "No actions found"}
 
     @mcp.tool(
         description=(
-            "Get complete action details including type, goal, result, and feedback structures. Works only with ROS 2.\n"
+            "Get complete action details including type, goal, result, and feedback structures.\n"
             "Example:\nget_action_details('/turtle1/rotate_absolute')"
         ),
         annotations=ToolAnnotations(
@@ -118,308 +124,63 @@ def register_action_tools(
             readOnlyHint=True,
         ),
     )
-    def get_action_details(action: str) -> dict:
+    def get_action_details(action: str, action_type: str = "") -> dict:
         """
-        Get complete action details including type, goal, result, and feedback structures. Works only with ROS 2.
+        Get complete action details including type, goal, result, and feedback structures.
 
         Args:
             action (str): The action name (e.g., '/turtle1/rotate_absolute')
+            action_type (str): The action type (e.g., 'turtlesim/action/RotateAbsolute').
+                Required. Use get_actions() to discover available action types.
 
         Returns:
             dict: Contains complete action definition with type, goal, result, and feedback structures.
         """
-        # Validate input
         if not action or not action.strip():
             return {"error": "Action name cannot be empty"}
 
-        # First, get the action type
-        action_type = "unknown"
-        action_interfaces = []  # Initialize before if/else block
-
-        # Check if required service is available
-        required_services = [rosapi_service("interfaces")]
-
-        with ws_manager:
-            # Get available services to check compatibility
-            services_message = {
-                "op": "call_service",
-                "service": rosapi_service("services"),
-                "type": rosapi_type("Services"),
-                "args": {},
-                "id": "check_services_for_get_action_type",
-            }
-
-            services_response = ws_manager.request(services_message)
-            if not services_response or not isinstance(services_response, dict):
-                return {
-                    "warning": "Cannot check service availability",
-                    "action": action,
-                    "compatibility": {
-                        "issue": "Cannot determine available services",
-                        "required_services": required_services,
-                        "suggestion": "Ensure rosbridge is running and rosapi is available",
-                    },
-                }
-
-            svc_values = _safe_get_values(services_response)
-            available_services = svc_values.get("services", []) if svc_values else []
-            missing_services = [svc for svc in required_services if svc not in available_services]
-
-            if missing_services:
-                return {
-                    "warning": "Action type resolution not supported by this rosbridge/rosapi version",
-                    "action": action,
-                    "compatibility": {
-                        "issue": "Required services are not available",
-                        "missing_services": missing_services,
-                        "required_services": required_services,
-                        "available_services": [s for s in available_services if "interface" in s],
-                        "suggestion": "This rosbridge version doesn't support interface listing services",
-                    },
-                }
-
-        # Known action type mappings
-        action_type_map = {
-            "/turtle1/rotate_absolute": "turtlesim/action/RotateAbsolute",
-            # Add more mappings as needed
-        }
-
-        # Check if it's a known action
-        if action in action_type_map:
-            action_type = action_type_map[action]
-        else:
-            # For unknown actions, try to derive the type from interfaces list
+        if not action_type or not action_type.strip():
+            # List available action types so the caller can provide one
             interfaces_message = {
                 "op": "call_service",
                 "service": rosapi_service("interfaces"),
                 "type": rosapi_type("Interfaces"),
                 "args": {},
-                "id": f"get_interfaces_for_action_{action.replace('/', '_')}",
+                "id": f"get_interfaces_for_{action.replace('/', '_')}",
             }
-
             with ws_manager:
                 interfaces_response = ws_manager.request(interfaces_message)
 
+            available = []
             iface_values = _safe_get_values(interfaces_response)
             if iface_values is not None:
-                interfaces = iface_values.get("interfaces", [])
-                # Look for action interfaces that might match
-                action_interfaces = [iface for iface in interfaces if "/action/" in iface]
-                # Try to match based on action name patterns
-                action_name_part = action.split("/")[-1]  # Get last part (e.g., "rotate_absolute")
-                for iface in action_interfaces:
-                    if action_name_part.lower() in iface.lower():
-                        action_type = iface
-                        break
+                available = [i for i in iface_values.get("interfaces", []) if "/action/" in i]
 
-        if action_type == "unknown":
             return {
-                "error": f"Action type for {action} not found",
+                "error": f"action_type is required for {action}",
                 "action": action,
-                "available_action_types": action_interfaces,
-                "suggestion": "This action might not be available or use a different naming pattern",
+                "available_action_types": available,
             }
 
-        # Now get action details using the action type
-        result = {
-            "action": action,
-            "action_type": action_type,
-            "goal": {},
-            "result": {},
-            "feedback": {},
-        }
-
-        # Check if required action detail services are available
-        required_detail_services = [
-            rosapi_service("action_goal_details"),
-            rosapi_service("action_result_details"),
-            rosapi_service("action_feedback_details"),
-        ]
-
+        # Fetch goal, result, and feedback structures
         with ws_manager:
-            # Get available services to check compatibility
-            services_message = {
-                "op": "call_service",
-                "service": rosapi_service("services"),
-                "type": rosapi_type("Services"),
-                "args": {},
-                "id": "check_services_for_action_details",
+            parts = {
+                part: _fetch_action_part(ws_manager, action_type, part) for part in _ACTION_PARTS
             }
 
-            services_response = ws_manager.request(services_message)
-            if not services_response or not isinstance(services_response, dict):
-                return {
-                    "error": "Failed to check service availability",
-                    "action": action,
-                    "action_type": action_type,
-                    "compatibility": {
-                        "issue": "Cannot determine available services",
-                        "required_services": required_detail_services,
-                        "suggestion": "Ensure rosbridge is running and rosapi is available",
-                    },
-                }
-
-            svc_values = _safe_get_values(services_response)
-            available_services = svc_values.get("services", []) if svc_values else []
-            missing_services = [
-                svc for svc in required_detail_services if svc not in available_services
-            ]
-
-            if missing_services:
-                # Return what we have (action type) even if details aren't available
-                return {
-                    "action": action,
-                    "action_type": action_type,
-                    "goal": {},
-                    "result": {},
-                    "feedback": {},
-                    "compatibility": {
-                        "issue": "Required action detail services are not available",
-                        "missing_services": missing_services,
-                        "required_services": required_detail_services,
-                        "available_services": [s for s in available_services if "action" in s],
-                        "note": "Action type found, but detailed structures are not available",
-                    },
-                }
-
-            # Get goal, result, and feedback details
-        # Get goal details using action-specific service
-        goal_message = {
-            "op": "call_service",
-            "service": rosapi_service("action_goal_details"),
-            "type": rosapi_type("ActionGoalDetails"),
-            "args": {"type": action_type},
-            "id": f"get_action_goal_details_{action_type.replace('/', '_')}",
-        }
-
-        goal_response = ws_manager.request(goal_message)
-        goal_values = _safe_get_values(goal_response)
-        if goal_values is not None and "error" not in goal_response:
-            typedefs = goal_values.get("typedefs", [])
-            if typedefs:
-                for typedef in typedefs:
-                    field_names = typedef.get("fieldnames", [])
-                    field_types = typedef.get("fieldtypes", [])
-                    field_array_len = typedef.get("fieldarraylen", [])
-                    examples = typedef.get("examples", [])
-                    const_names = typedef.get("constnames", [])
-                    const_values = typedef.get("constvalues", [])
-
-                    fields = {}
-                    field_details = {}
-                    for i, (name, ftype) in enumerate(zip(field_names, field_types)):
-                        fields[name] = ftype
-                        field_details[name] = {
-                            "type": ftype,
-                            "array_length": field_array_len[i] if i < len(field_array_len) else -1,
-                            "example": examples[i] if i < len(examples) else None,
-                        }
-
-                    result["goal"] = {
-                        "fields": fields,
-                        "field_count": len(fields),
-                        "field_details": field_details,
-                        "message_type": typedef.get("type", ""),
-                        "examples": examples,
-                        "constants": dict(zip(const_names, const_values)) if const_names else {},
-                    }
-
-        # Get result details using action-specific service
-        result_message = {
-            "op": "call_service",
-            "service": rosapi_service("action_result_details"),
-            "type": rosapi_type("ActionResultDetails"),
-            "args": {"type": action_type},
-            "id": f"get_action_result_details_{action_type.replace('/', '_')}",
-        }
-
-        result_response = ws_manager.request(result_message)
-        res_values = _safe_get_values(result_response)
-        if res_values is not None and "error" not in result_response:
-            typedefs = res_values.get("typedefs", [])
-            if typedefs:
-                for typedef in typedefs:
-                    field_names = typedef.get("fieldnames", [])
-                    field_types = typedef.get("fieldtypes", [])
-                    field_array_len = typedef.get("fieldarraylen", [])
-                    examples = typedef.get("examples", [])
-                    const_names = typedef.get("constnames", [])
-                    const_values = typedef.get("constvalues", [])
-
-                    fields = {}
-                    field_details = {}
-                    for i, (name, ftype) in enumerate(zip(field_names, field_types)):
-                        fields[name] = ftype
-                        field_details[name] = {
-                            "type": ftype,
-                            "array_length": field_array_len[i] if i < len(field_array_len) else -1,
-                            "example": examples[i] if i < len(examples) else None,
-                        }
-
-                    result["result"] = {
-                        "fields": fields,
-                        "field_count": len(fields),
-                        "field_details": field_details,
-                        "message_type": typedef.get("type", ""),
-                        "examples": examples,
-                        "constants": dict(zip(const_names, const_values)) if const_names else {},
-                    }
-
-        # Get feedback details using action-specific service
-        feedback_message = {
-            "op": "call_service",
-            "service": rosapi_service("action_feedback_details"),
-            "type": rosapi_type("ActionFeedbackDetails"),
-            "args": {"type": action_type},
-            "id": f"get_action_feedback_details_{action_type.replace('/', '_')}",
-        }
-
-        feedback_response = ws_manager.request(feedback_message)
-        fb_values = _safe_get_values(feedback_response)
-        if fb_values is not None and "error" not in feedback_response:
-            typedefs = fb_values.get("typedefs", [])
-            if typedefs:
-                for typedef in typedefs:
-                    field_names = typedef.get("fieldnames", [])
-                    field_types = typedef.get("fieldtypes", [])
-                    field_array_len = typedef.get("fieldarraylen", [])
-                    examples = typedef.get("examples", [])
-                    const_names = typedef.get("constnames", [])
-                    const_values = typedef.get("constvalues", [])
-
-                    fields = {}
-                    field_details = {}
-                    for i, (name, ftype) in enumerate(zip(field_names, field_types)):
-                        fields[name] = ftype
-                        field_details[name] = {
-                            "type": ftype,
-                            "array_length": field_array_len[i] if i < len(field_array_len) else -1,
-                            "example": examples[i] if i < len(examples) else None,
-                        }
-
-                    result["feedback"] = {
-                        "fields": fields,
-                        "field_count": len(fields),
-                        "field_details": field_details,
-                        "message_type": typedef.get("type", ""),
-                        "examples": examples,
-                        "constants": dict(zip(const_names, const_values)) if const_names else {},
-                    }
-
-        # Check if we got any data
-        if not result["goal"] and not result["result"] and not result["feedback"]:
+        if not any(parts.values()):
             return {
+                "error": f"Action type {action_type} found but has no definition",
                 "action": action,
                 "action_type": action_type,
-                "error": f"Action type {action_type} found but has no definition",
             }
 
-        return result
+        return {"action": action, "action_type": action_type, **parts}
 
     @mcp.tool(
         description=(
             "Get action status for a specific action name. Works only with ROS 2.\n"
-            "Example:\nget_action_status('/fibonacci')"
+            "Example:\nget_action_status('/turtle1/rotate_absolute')"
         ),
         annotations=ToolAnnotations(
             title="Get Action Status",
@@ -431,112 +192,96 @@ def register_action_tools(
         Get action status for a specific action name. Works only with ROS 2.
 
         Args:
-            action_name (str): The action name (e.g., '/fibonacci')
+            action_name (str): The action name (e.g., '/turtle1/rotate_absolute')
 
         Returns:
             dict: Contains action status information including active goals and their status.
         """
-        # Validate input
         if not action_name or not action_name.strip():
             return {"error": "Action name cannot be empty"}
 
-        # Ensure action name starts with /
         if not action_name.startswith("/"):
             action_name = f"/{action_name}"
 
-        # Try to get action status by subscribing to the status topic
         status_topic = f"{action_name}/_action/status"
         status_msg_type = "action_msgs/msg/GoalStatusArray"
 
-        try:
-            # Subscribe to action status topic
-            with ws_manager:
-                message = {
-                    "op": "subscribe",
-                    "topic": status_topic,
-                    "type": status_msg_type,
-                    "id": f"get_action_status_{action_name.replace('/', '_')}",
-                }
+        status_map = {
+            0: "STATUS_UNKNOWN",
+            1: "STATUS_ACCEPTED",
+            2: "STATUS_EXECUTING",
+            3: "STATUS_CANCELING",
+            4: "STATUS_SUCCEEDED",
+            5: "STATUS_CANCELED",
+            6: "STATUS_ABORTED",
+        }
 
-                send_error = ws_manager.send(message)
+        try:
+            with ws_manager:
+                send_error = ws_manager.send(
+                    {
+                        "op": "subscribe",
+                        "topic": status_topic,
+                        "type": status_msg_type,
+                        "id": f"get_action_status_{action_name.replace('/', '_')}",
+                    }
+                )
                 if send_error:
                     return {
-                        "action_name": action_name,
-                        "success": False,
                         "error": f"Failed to subscribe to status topic: {send_error}",
+                        "action_name": action_name,
                     }
 
-                # Wait for status message
                 response = ws_manager.receive(timeout=3.0)
+
+                # Unsubscribe regardless of result
+                ws_manager.send({"op": "unsubscribe", "topic": status_topic})
+
                 if not response:
                     return {
-                        "action_name": action_name,
-                        "success": False,
                         "error": "No response from action status topic",
+                        "action_name": action_name,
                     }
 
                 response_data = json.loads(response)
 
                 if response_data.get("op") == "status" and response_data.get("level") == "error":
                     return {
-                        "error": f"Action status error: {response_data.get('msg', 'Unknown error')}"
+                        "error": f"Action status error: {response_data.get('msg', 'Unknown error')}",
+                        "action_name": action_name,
                     }
 
-                if "msg" not in response_data or "status_list" not in response_data["msg"]:
+                if "msg" not in response_data or "status_list" not in response_data.get("msg", {}):
                     return {
                         "action_name": action_name,
-                        "success": True,
                         "active_goals": [],
                         "goal_count": 0,
-                        "note": f"No active goals found for action {action_name}",
                     }
 
-                status_list = response_data["msg"]["status_list"]
-                status_map = {
-                    0: "STATUS_UNKNOWN",
-                    1: "STATUS_ACCEPTED",
-                    2: "STATUS_EXECUTING",
-                    3: "STATUS_CANCELING",
-                    4: "STATUS_SUCCEEDED",
-                    5: "STATUS_CANCELED",
-                    6: "STATUS_ABORTED",
-                }
-
                 active_goals = []
-                for status_item in status_list:
-                    goal_info = status_item.get("goal_info", {})
-                    goal_id = goal_info.get("goal_id", {}).get("uuid", "unknown")
-                    status = status_item.get("status", -1)
+                for item in response_data["msg"]["status_list"]:
+                    goal_info = item.get("goal_info", {})
+                    status = item.get("status", -1)
                     stamp = goal_info.get("stamp", {})
-
                     active_goals.append(
                         {
-                            "goal_id": goal_id,
+                            "goal_id": goal_info.get("goal_id", {}).get("uuid", "unknown"),
                             "status": status,
                             "status_text": status_map.get(status, "UNKNOWN"),
                             "timestamp": f"{stamp.get('sec', 0)}.{stamp.get('nanosec', 0)}",
                         }
                     )
 
-                # Unsubscribe
-                ws_manager.send({"op": "unsubscribe", "topic": status_topic})
-
                 return {
                     "action_name": action_name,
-                    "success": True,
                     "active_goals": active_goals,
                     "goal_count": len(active_goals),
-                    "note": f"Found {len(active_goals)} active goal(s) for action {action_name}",
                 }
 
         except json.JSONDecodeError as e:
-            return {"error": f"Failed to parse status response: {str(e)}"}
+            return {"error": f"Failed to parse status response: {e}"}
         except Exception as e:
-            return {
-                "action_name": action_name,
-                "success": False,
-                "error": f"Failed to get action status: {str(e)}",
-            }
+            return {"error": f"Failed to get action status: {e}", "action_name": action_name}
 
     @mcp.tool(
         description=(
@@ -567,124 +312,94 @@ def register_action_tools(
         Returns:
             dict: Contains action response including goal_id, status, and result.
         """
-        # Validate inputs
         if not action_name or not action_name.strip():
             return {"error": "Action name cannot be empty"}
-
         if not action_type or not action_type.strip():
             return {"error": "Action type cannot be empty"}
-
         if not goal:
             return {"error": "Goal cannot be empty"}
 
-        # Use ws_manager.default_timeout if timeout is None
         if timeout is None:
             timeout = ws_manager.default_timeout
 
-        # Generate unique goal ID
         goal_id = f"goal_{int(time.time() * 1000)}_{uuid.uuid4().hex[:8]}"
 
-        # rosbridge action goal message
-        # Based on rosbridge source code, it expects "args" instead of "goal"
         message = {
             "op": "send_action_goal",
             "id": goal_id,
             "action": action_name,
             "action_type": action_type,
-            "args": goal,  # rosbridge expects "args" not "goal"
-            "feedback": True,  # Enable feedback messages
+            "args": goal,
+            "feedback": True,
         }
 
-        # Send the action goal through rosbridge
         with ws_manager:
             send_error = ws_manager.send(message)
             if send_error:
                 return {
-                    "action": action_name,
-                    "action_type": action_type,
-                    "success": False,
                     "error": f"Failed to send action goal: {send_error}",
+                    "action": action_name,
+                    "success": False,
                 }
 
-            # Wait for action completion - handle both action_result and action_feedback
             start_time = time.time()
-            last_feedback = None  # Store the last feedback message
-            feedback_count = 0  # Count feedback messages received
+            last_feedback = None
+            feedback_count = 0
 
             while time.time() - start_time < timeout:
-                elapsed_time = time.time() - start_time
+                remaining = timeout - (time.time() - start_time)
+                response = ws_manager.receive(remaining)
 
-                response = ws_manager.receive(timeout - elapsed_time)
+                if not response:
+                    continue
 
-                if response:
-                    try:
-                        msg_data = json.loads(response)
-
-                        # Handle action_result messages (final completion)
-                        if msg_data.get("op") == "action_result":
-                            # Report completion
-                            if ctx:
-                                try:
-                                    completion_msg = f"Action completed successfully (received {feedback_count} feedback messages)"
-                                    await ctx.report_progress(
-                                        progress=feedback_count, total=None, message=completion_msg
-                                    )
-                                except Exception:
-                                    pass
-
-                            return {
-                                "action": action_name,
-                                "action_type": action_type,
-                                "success": True,
-                                "goal_id": goal_id,
-                                "status": msg_data.get("status", "unknown"),
-                                "result": msg_data.get("values", {}),
-                            }
-
-                        # Store action_feedback messages and report progress
-                        if msg_data.get("op") == "action_feedback":
-                            feedback_count += 1
-                            last_feedback = msg_data
-
-                            # Report feedback progress
-                            if ctx:
-                                try:
-                                    feedback_values = msg_data.get("values", {})
-                                    feedback_msg = f"Action feedback #{feedback_count}: {str(feedback_values)[:100]}..."
-                                    await ctx.report_progress(
-                                        progress=feedback_count, total=None, message=feedback_msg
-                                    )
-                                except Exception:
-                                    pass
-
-                    except json.JSONDecodeError:
-                        continue
-
-            # Timeout - return last feedback if available
-            if ctx and feedback_count > 0:
                 try:
-                    await ctx.report_progress(
-                        progress=feedback_count,
-                        total=None,
-                        message=f"Action timed out after {timeout} seconds (received {feedback_count} feedback messages)",
-                    )
-                except Exception:
-                    pass
+                    msg_data = json.loads(response)
+                except json.JSONDecodeError:
+                    continue
 
-            result = {
-                "action": action_name,
-                "action_type": action_type,
-                "success": False,
-                "goal_id": goal_id,
-                "error": f"Action timed out after {timeout} seconds",
-            }
+                if msg_data.get("op") == "action_result":
+                    if ctx:
+                        try:
+                            await ctx.report_progress(
+                                progress=feedback_count, total=None, message="Action completed"
+                            )
+                        except Exception:
+                            pass
+                    return {
+                        "action": action_name,
+                        "action_type": action_type,
+                        "success": True,
+                        "goal_id": goal_id,
+                        "status": msg_data.get("status", "unknown"),
+                        "result": msg_data.get("values", {}),
+                    }
 
-            if last_feedback:
-                result["success"] = True
-                result["last_feedback"] = last_feedback.get("values", {})
-                result["note"] = "Action timed out, but partial progress was made"
+                if msg_data.get("op") == "action_feedback":
+                    feedback_count += 1
+                    last_feedback = msg_data
+                    if ctx:
+                        try:
+                            await ctx.report_progress(
+                                progress=feedback_count,
+                                total=None,
+                                message=f"Feedback #{feedback_count}: {str(msg_data.get('values', {}))[:100]}",
+                            )
+                        except Exception:
+                            pass
 
-            return result
+        # Timeout
+        result = {
+            "action": action_name,
+            "action_type": action_type,
+            "success": False,
+            "goal_id": goal_id,
+            "error": f"Action timed out after {timeout} seconds",
+        }
+        if last_feedback:
+            result["last_feedback"] = last_feedback.get("values", {})
+            result["feedback_count"] = feedback_count
+        return result
 
     @mcp.tool(
         description=(
@@ -707,36 +422,28 @@ def register_action_tools(
         Returns:
             dict: Contains cancellation status and result.
         """
-        # Validate inputs
         if not action_name or not action_name.strip():
             return {"error": "Action name cannot be empty"}
-
         if not goal_id or not goal_id.strip():
             return {"error": "Goal ID cannot be empty"}
 
-        # Create cancel message for rosbridge (based on rosbridge source code)
-        cancel_message = {
-            "op": "cancel_action_goal",
-            "id": goal_id,  # Use the actual goal ID, not a new one
-            "action": action_name,
-            "feedback": True,  # Enable feedback messages
-        }
-
-        # Send the cancel request through rosbridge
         with ws_manager:
-            # Send cancel request
-            send_error = ws_manager.send(cancel_message)
+            send_error = ws_manager.send(
+                {
+                    "op": "cancel_action_goal",
+                    "id": goal_id,
+                    "action": action_name,
+                }
+            )
             if send_error:
                 return {
+                    "error": f"Failed to send cancel request: {send_error}",
                     "action": action_name,
                     "goal_id": goal_id,
-                    "success": False,
-                    "error": f"Failed to send cancel request: {send_error}",
                 }
 
         return {
             "action": action_name,
             "goal_id": goal_id,
             "success": True,
-            "note": "Cancel request sent successfully. Action may still be executing.",
         }

--- a/ros_mcp/tools/actions.py
+++ b/ros_mcp/tools/actions.py
@@ -103,8 +103,11 @@ def register_action_tools(
 
     @mcp.tool(
         description=(
-            "Get complete action details including type, goal, result, and feedback structures.\n"
-            "Example:\nget_action_details('/turtle1/rotate_absolute')"
+            "Get complete action details including goal, result, and feedback structures. "
+            "Requires the action type; if you don't know it, call without action_type to get "
+            "the list of available types back in the error.\n"
+            "Example:\n"
+            "get_action_details('/turtle1/rotate_absolute', 'turtlesim/action/RotateAbsolute')"
         ),
         annotations=ToolAnnotations(
             title="Get Action Details",
@@ -113,15 +116,17 @@ def register_action_tools(
     )
     def get_action_details(action: str, action_type: str = "") -> dict:
         """
-        Get complete action details including type, goal, result, and feedback structures.
+        Get complete action details including goal, result, and feedback structures.
 
         Args:
             action (str): The action name (e.g., '/turtle1/rotate_absolute')
             action_type (str): The action type (e.g., 'turtlesim/action/RotateAbsolute').
-                Required. Use get_actions() to discover available action types.
+                Required. Call without action_type to get the available types back
+                in the error (they are also listed by the interfaces service, not
+                by get_actions(), which returns action *names*).
 
         Returns:
-            dict: Contains complete action definition with type, goal, result, and feedback structures.
+            dict: Contains complete action definition with goal, result, and feedback structures.
         """
         if not action or not action.strip():
             return {"error": "Action name cannot be empty"}
@@ -141,6 +146,7 @@ def register_action_tools(
                     "id": f"get_interfaces_for_{action.replace('/', '_')}",
                 }
             )
+            interfaces_error = _check_response(interfaces_response)
             iface_values = _safe_get_values(interfaces_response)
             available = (
                 [i for i in iface_values.get("interfaces", []) if "/action/" in i]
@@ -153,6 +159,19 @@ def register_action_tools(
                     "error": f"action_type is required for {action}",
                     "action": action,
                     "available_action_types": available,
+                }
+
+            # If the interfaces list is unavailable we cannot validate the type,
+            # and we must not fall through to the detail services (a bad type
+            # crashes rosapi). Report that distinctly from a genuine "not found".
+            if interfaces_error:
+                return {
+                    "error": (
+                        f"Cannot validate action_type for {action}: "
+                        "the action interfaces service is unavailable"
+                    ),
+                    "action": action,
+                    "action_type": action_type,
                 }
 
             if action_type not in available:
@@ -238,9 +257,13 @@ def register_action_tools(
                 ws_manager.send({"op": "unsubscribe", "topic": status_topic})
 
                 if not response:
+                    # An idle action server may not publish status; that is not
+                    # an error, just no goals in flight.
                     return {
-                        "error": "No response from action status topic",
                         "action_name": action_name,
+                        "active_goals": [],
+                        "goal_count": 0,
+                        "note": "No status published; the action is idle or not running",
                     }
 
                 response_data = json.loads(response)
@@ -318,6 +341,9 @@ def register_action_tools(
             return {"error": "Action type cannot be empty"}
         if not goal:
             return {"error": "Goal cannot be empty"}
+
+        if not action_name.startswith("/"):
+            action_name = f"/{action_name}"
 
         if timeout is None:
             timeout = ws_manager.default_timeout
@@ -427,6 +453,9 @@ def register_action_tools(
         if not goal_id or not goal_id.strip():
             return {"error": "Goal ID cannot be empty"}
 
+        if not action_name.startswith("/"):
+            action_name = f"/{action_name}"
+
         with ws_manager:
             send_error = ws_manager.send(
                 {
@@ -442,8 +471,11 @@ def register_action_tools(
                     "goal_id": goal_id,
                 }
 
+        # success here confirms the request was sent, not that the server
+        # accepted it — the action may still be executing.
         return {
             "action": action_name,
             "goal_id": goal_id,
             "success": True,
+            "note": "Cancel request sent; the action may still be executing",
         }

--- a/ros_mcp/tools/actions.py
+++ b/ros_mcp/tools/actions.py
@@ -20,32 +20,19 @@ _ACTION_PARTS = {
 
 
 def _parse_typedef(typedef: dict) -> dict:
-    """Parse a rosapi typedef into a structured field description."""
+    """Parse a rosapi typedef into a field-name -> type mapping.
+
+    Mirrors the shape produced by get_message_details (topics) and
+    get_service_details (services): a ``fields`` dict plus ``field_count``.
+    """
     field_names = typedef.get("fieldnames", [])
     field_types = typedef.get("fieldtypes", [])
-    field_array_len = typedef.get("fieldarraylen", [])
-    examples = typedef.get("examples", [])
-    const_names = typedef.get("constnames", [])
-    const_values = typedef.get("constvalues", [])
 
     fields = {}
-    field_details = {}
-    for i, (name, ftype) in enumerate(zip(field_names, field_types)):
+    for name, ftype in zip(field_names, field_types):
         fields[name] = ftype
-        field_details[name] = {
-            "type": ftype,
-            "array_length": field_array_len[i] if i < len(field_array_len) else -1,
-            "example": examples[i] if i < len(examples) else None,
-        }
 
-    return {
-        "fields": fields,
-        "field_count": len(fields),
-        "field_details": field_details,
-        "message_type": typedef.get("type", ""),
-        "examples": examples,
-        "constants": dict(zip(const_names, const_values)) if const_names else {},
-    }
+    return {"fields": fields, "field_count": len(fields)}
 
 
 def _fetch_action_part(ws_manager: WebSocketManager, action_type: str, part: str) -> dict:

--- a/tests/integration/docker/Dockerfile.ros1-melodic
+++ b/tests/integration/docker/Dockerfile.ros1-melodic
@@ -8,6 +8,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-rosbridge-suite \
     ros-melodic-turtlesim \
+    ros-melodic-turtle-actionlib \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ros_ws

--- a/tests/integration/docker/Dockerfile.ros1-noetic
+++ b/tests/integration/docker/Dockerfile.ros1-noetic
@@ -8,6 +8,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-rosbridge-suite \
     ros-noetic-turtlesim \
+    ros-noetic-turtle-actionlib \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ros_ws

--- a/tests/integration/docker/ros1_launch.launch
+++ b/tests/integration/docker/ros1_launch.launch
@@ -10,4 +10,6 @@
   <node pkg="rosapi" type="rosapi_node" name="rosapi" output="screen" />
 
   <node pkg="turtlesim" type="turtlesim_node" name="turtlesim" output="screen" />
+
+  <node pkg="turtle_actionlib" type="shape_server" name="turtle_shape" output="screen" />
 </launch>

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -1,0 +1,108 @@
+"""Integration tests for action tools.
+
+These tests call the actual MCP tool functions (get_actions, get_action_details,
+get_action_status) against a live rosbridge container.
+
+Action servers per distro:
+- ROS 1 (melodic/noetic): /shape_server (from turtle_actionlib)
+- ROS 2 (humble/jazzy): /turtle1/rotate_absolute (from turtlesim)
+
+get_action_details and get_action_status use ROS 2-only rosbridge features
+(/rosapi/interfaces, send_action_goal op). See issue #320 for ROS 1 support
+via the 5-topic actionlib pattern.
+"""
+
+import pytest
+
+from ros_mcp.utils.rosapi_types import RosVersion, get_ros_version
+
+pytestmark = [pytest.mark.integration]
+
+
+_ACTIONS = {
+    RosVersion.ROS1: {
+        "name": "/turtle_shape",
+        "type": "turtle_actionlib/ShapeAction",
+    },
+    RosVersion.ROS2: {
+        "name": "/turtle1/rotate_absolute",
+        "type": "turtlesim/action/RotateAbsolute",
+    },
+}
+
+
+def _action():
+    """Return the action dict (name, type) for the current distro."""
+    return _ACTIONS[get_ros_version()]
+
+
+class TestGetActions:
+    """Verify get_actions MCP tool returns the action list."""
+
+    def test_returns_actions(self, tools):
+        """get_actions should return actions and action_count."""
+        result = tools["get_actions"]()
+        assert "actions" in result
+        assert "action_count" in result
+        assert result["action_count"] > 0
+        assert result["action_count"] == len(result["actions"])
+
+    def test_includes_expected_action(self, tools):
+        """The expected action server should be present."""
+        result = tools["get_actions"]()
+        actions = result["actions"]
+        expected = _action()["name"]
+        assert any(expected in a for a in actions), f"{expected} not in {actions}"
+
+
+class TestGetActionDetails:
+    """Verify get_action_details MCP tool returns action structure.
+
+    Detail inspection requires /rosapi/interfaces (ROS 2 only).
+    """
+
+    @pytest.mark.skipif(
+        "get_ros_version() != RosVersion.ROS2",
+        reason="Action detail inspection requires /rosapi/interfaces (ROS 2 only, see #320)",
+    )
+    def test_action_details(self, tools):
+        """get_action_details should return goal/result/feedback structure."""
+        action = _action()["name"]
+        result = tools["get_action_details"](action=action, action_type=_action()["type"])
+        assert result["action"] == action
+        assert "goal" in result
+        assert "result" in result
+        assert "feedback" in result
+        assert result["goal"]["field_count"] > 0
+
+    def test_empty_action_returns_error(self, tools):
+        """get_action_details with empty string should return error."""
+        result = tools["get_action_details"](action="")
+        assert "error" in result
+
+    def test_nonexistent_action_returns_error(self, tools):
+        """get_action_details for nonexistent action should return error."""
+        result = tools["get_action_details"](action="/nonexistent_action_xyz")
+        assert "error" in result
+
+
+class TestGetActionStatus:
+    """Verify get_action_status MCP tool returns status info.
+
+    Status subscription works on ROS 2. On ROS 1, the status topic
+    format differs (see #320).
+    """
+
+    @pytest.mark.skipif(
+        "get_ros_version() != RosVersion.ROS2",
+        reason="Action status subscription uses ROS 2 topic format (see #320)",
+    )
+    def test_action_status(self, tools):
+        """get_action_status should return status structure."""
+        result = tools["get_action_status"](action_name=_action()["name"])
+        assert "action_name" in result
+
+    def test_empty_action_returns_error(self, tools):
+        """get_action_status with empty string should return error."""
+        result = tools["get_action_status"](action_name="")
+        assert "error" in result

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -1,7 +1,8 @@
 """Integration tests for action tools.
 
 These tests call the actual MCP tool functions (get_actions, get_action_details,
-get_action_status) against a live rosbridge container.
+get_action_status, send_action_goal, cancel_action_goal) against a live
+rosbridge container.
 
 Action servers per distro:
 - ROS 1 (melodic/noetic): /shape_server (from turtle_actionlib)
@@ -11,6 +12,8 @@ get_action_details and get_action_status use ROS 2-only rosbridge features
 (/rosapi/interfaces, send_action_goal op). See issue #320 for ROS 1 support
 via the 5-topic actionlib pattern.
 """
+
+import asyncio
 
 import pytest
 
@@ -88,6 +91,10 @@ class TestGetActionDetails:
         # The caller is told which types they could pass instead.
         assert isinstance(result["available_action_types"], list)
 
+    @pytest.mark.skipif(
+        "get_ros_version() != RosVersion.ROS2",
+        reason="action_type validation/crash is ROS 2 rosapi-specific (see #320)",
+    )
     def test_nonexistent_action_type_does_not_crash_rosapi(self, tools):
         """A bogus action_type must be rejected WITHOUT crashing rosapi.
 
@@ -131,19 +138,85 @@ class TestGetActionStatus:
         reason="Action status subscription uses ROS 2 topic format (see #320)",
     )
     def test_action_status(self, tools):
-        """get_action_status should echo the action and report well-formed status.
+        """get_action_status should echo the action and report goal status.
 
-        With no goal in flight the status topic may not publish, so a "no
-        response" error is acceptable; what must hold is that the action name is
-        echoed and, when a status is returned, goal_count matches the goal list.
+        With no goal in flight the action is reported as idle (goal_count 0),
+        not an error; goal_count must always match the active_goals list.
         """
         action_name = _action()["name"]
         result = tools["get_action_status"](action_name=action_name)
         assert result.get("action_name") == action_name
-        if "error" not in result:
-            assert result["goal_count"] == len(result["active_goals"])
+        assert "error" not in result, f"unexpected error: {result}"
+        assert result["goal_count"] == len(result["active_goals"])
 
     def test_empty_action_returns_error(self, tools):
         """get_action_status with empty string should return error."""
         result = tools["get_action_status"](action_name="")
         assert "error" in result
+
+
+class TestSendActionGoal:
+    """Verify send_action_goal MCP tool.
+
+    Sending a goal uses the ROS 2 rosbridge ``send_action_goal`` op; on ROS 1
+    actions use a different transport (see #320). The async tool is driven with
+    ``asyncio.run`` since the suite has no asyncio plugin.
+    """
+
+    def test_empty_action_returns_error(self, tools):
+        result = asyncio.run(
+            tools["send_action_goal"](action_name="", action_type="x", goal={"a": 1})
+        )
+        assert "error" in result
+
+    def test_empty_type_returns_error(self, tools):
+        result = asyncio.run(
+            tools["send_action_goal"](action_name="/a", action_type="", goal={"a": 1})
+        )
+        assert "error" in result
+
+    def test_empty_goal_returns_error(self, tools):
+        result = asyncio.run(tools["send_action_goal"](action_name="/a", action_type="x", goal={}))
+        assert "error" in result
+
+    @pytest.mark.skipif(
+        "get_ros_version() != RosVersion.ROS2",
+        reason="send_action_goal uses the ROS 2 rosbridge action op (see #320)",
+    )
+    def test_send_goal_completes(self, tools):
+        """A goal to rotate_absolute should run to completion and return a result."""
+        action = _action()
+        result = asyncio.run(
+            tools["send_action_goal"](
+                action_name=action["name"],
+                action_type=action["type"],
+                goal={"theta": 1.0},
+                timeout=10.0,
+            )
+        )
+        assert result["success"] is True, f"goal did not complete: {result}"
+        assert result["goal_id"]
+        assert "result" in result
+
+
+class TestCancelActionGoal:
+    """Verify cancel_action_goal MCP tool."""
+
+    def test_empty_action_returns_error(self, tools):
+        result = tools["cancel_action_goal"](action_name="", goal_id="g")
+        assert "error" in result
+
+    def test_empty_goal_id_returns_error(self, tools):
+        result = tools["cancel_action_goal"](action_name="/a", goal_id="")
+        assert "error" in result
+
+    @pytest.mark.skipif(
+        "get_ros_version() != RosVersion.ROS2",
+        reason="cancel_action_goal uses the ROS 2 rosbridge action op (see #320)",
+    )
+    def test_cancel_request_sent(self, tools):
+        """Cancelling reports success once the request is sent (not server-acked)."""
+        action_name = _action()["name"]
+        result = tools["cancel_action_goal"](action_name=action_name, goal_id="nonexistent_goal")
+        assert result["success"] is True
+        assert result["action"] == action_name

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -81,22 +81,42 @@ class TestGetActionDetails:
         assert "error" in result
 
     def test_missing_action_type_returns_error(self, tools):
-        """get_action_details without action_type should error (action_type is required)."""
+        """Without action_type, the error must also list the available types."""
         result = tools["get_action_details"](action="/nonexistent_action_xyz")
         assert "error" in result
+        assert "action_type is required" in result["error"]
+        # The caller is told which types they could pass instead.
+        assert isinstance(result["available_action_types"], list)
 
-    def test_nonexistent_action_type_returns_error(self, tools):
-        """A bogus action_type must be rejected via the interfaces check.
+    def test_nonexistent_action_type_does_not_crash_rosapi(self, tools):
+        """A bogus action_type must be rejected WITHOUT crashing rosapi.
 
-        get_action_details validates the type against /rosapi/interfaces before
-        querying its details, because asking rosapi for the goal/result/feedback
-        of a non-existent type crashes the ROS 2 rosapi node.
+        get_action_details validates action_type against /rosapi/interfaces
+        before querying its details, because asking rosapi for the
+        goal/result/feedback of a non-existent type crashes the ROS 2 rosapi
+        node — taking down every rosapi service for the rest of the session.
+        This test locks in that guard: it asserts the type is rejected AND that
+        rosapi is still answering afterwards.
         """
         result = tools["get_action_details"](
             action="/nonexistent_action_xyz",
             action_type="nonexistent_pkg/action/DoesNotExist",
         )
+        # An unknown type must be reported as an error, never silently accepted.
         assert "error" in result
+
+        # The crash check — this is the assertion that catches the regression,
+        # independent of how the error is worded. Querying detail services for a
+        # non-existent type used to kill the ROS 2 rosapi node; a follow-up
+        # rosapi-backed call then fails with "service does not exist". If the
+        # guard is removed, this assertion fails here.
+        nodes_result = tools["get_nodes"]()
+        assert "nodes" in nodes_result, f"rosapi crashed after bogus action_type: {nodes_result}"
+
+        # The rejection should come from the interfaces validation, not from
+        # reaching (and crashing on) the detail services.
+        assert "not found" in result["error"].lower()
+        assert isinstance(result["available_action_types"], list)
 
 
 class TestGetActionStatus:
@@ -111,9 +131,17 @@ class TestGetActionStatus:
         reason="Action status subscription uses ROS 2 topic format (see #320)",
     )
     def test_action_status(self, tools):
-        """get_action_status should return status structure."""
-        result = tools["get_action_status"](action_name=_action()["name"])
-        assert "action_name" in result
+        """get_action_status should echo the action and report well-formed status.
+
+        With no goal in flight the status topic may not publish, so a "no
+        response" error is acceptable; what must hold is that the action name is
+        echoed and, when a status is returned, goal_count matches the goal list.
+        """
+        action_name = _action()["name"]
+        result = tools["get_action_status"](action_name=action_name)
+        assert result.get("action_name") == action_name
+        if "error" not in result:
+            assert result["goal_count"] == len(result["active_goals"])
 
     def test_empty_action_returns_error(self, tools):
         """get_action_status with empty string should return error."""

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -80,9 +80,17 @@ class TestGetActionDetails:
         result = tools["get_action_details"](action="")
         assert "error" in result
 
-    def test_nonexistent_action_returns_error(self, tools):
-        """get_action_details for nonexistent action should return error."""
+    def test_missing_action_type_returns_error(self, tools):
+        """get_action_details without action_type should error (action_type is required)."""
         result = tools["get_action_details"](action="/nonexistent_action_xyz")
+        assert "error" in result
+
+    def test_nonexistent_action_type_returns_error(self, tools):
+        """get_action_details with a bogus action_type should return a no-definition error."""
+        result = tools["get_action_details"](
+            action="/nonexistent_action_xyz",
+            action_type="nonexistent_pkg/action/DoesNotExist",
+        )
         assert "error" in result
 
 

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -86,7 +86,12 @@ class TestGetActionDetails:
         assert "error" in result
 
     def test_nonexistent_action_type_returns_error(self, tools):
-        """get_action_details with a bogus action_type should return a no-definition error."""
+        """A bogus action_type must be rejected via the interfaces check.
+
+        get_action_details validates the type against /rosapi/interfaces before
+        querying its details, because asking rosapi for the goal/result/feedback
+        of a non-existent type crashes the ROS 2 rosapi node.
+        """
         result = tools["get_action_details"](
             action="/nonexistent_action_xyz",
             action_type="nonexistent_pkg/action/DoesNotExist",


### PR DESCRIPTION
## Summary

Step 5 of 7 — rebased onto `develop` after step 4 (#322) was squash-merged.

- Migrate 21 hardcoded `/rosapi/` strings in `actions.py` to `rosapi_service()`/`rosapi_type()`
- Refactor action tools to match the nodes/topics/services pattern (`_check_response`/`_safe_get_values`, `with ws_manager:`)
- `_parse_typedef` returns the same `{fields, field_count}` shape as `get_message_details`/`get_service_details`
- Remove redundant service-availability pre-flights, hardcoded `action_type_map`, triplicated typedef parsing, and the `asyncio.sleep` that caused missed results
- Add `turtle_actionlib` to ROS 1 Docker images + a `/turtle_shape` action server for ROS 1 action testing
- Integration tests for `get_actions`, `get_action_details`, `get_action_status` across all distros

## Fix: unknown `action_type` no longer crashes the ROS 2 rosapi node

The first CI run was red on humble/jazzy (30 failures). Root cause (reproduced locally, not flaky): `get_action_details` queried `/rosapi/action_goal_details` (+ result/feedback) for a non-existent action type, which **crashes the ROS 2 `rosapi` node**. Once `/rosapi` died, every later rosapi call failed -> version detection fell back to ROS 1 -> all `detect/nodes/topics/services` tests cascade-failed.

- `get_action_details` now validates `action_type` against `/rosapi/interfaces` **before** calling the detail services. An unknown type returns `Action type '...' not found` (with `available_action_types`) instead of reaching — and crashing — rosapi. This also protects real callers from killing their rosapi node with a typo.
- Added a negative regression test, `test_nonexistent_action_type_does_not_crash_rosapi`, that asserts rosapi is still answering after a bogus type (it fails with `rosapi crashed after bogus action_type` if the guard is removed — verified). Tightened the other error-path assertions away from bare key-presence checks.

> The underlying rosapi crash on introspecting a non-existent action type is an upstream ROS 2 `rosapi` bug worth reporting separately; the client-side guard makes us robust regardless.

## Changes

- **`ros_mcp/tools/actions.py`** — refactor + migrate (747 -> ~435 lines); validate `action_type` before detail queries
- **`tests/integration/test_actions.py`** — tests for actions list, details (ROS 2), status (ROS 2), and error paths (empty action, missing action_type, nonexistent action type + rosapi-survival assertion)
- **`Dockerfile.ros1-melodic/noetic`** — add `turtle-actionlib`
- **`ros1_launch.launch`** — add `/turtle_shape` (`shape_server`) action node

## Testing

Full integration suite verified locally on every distro (no mocks — live rosbridge containers):

| Distro | Result | rosapi |
|--------|--------|--------|
| humble (ROS 2) | 69 passed | survives |
| jazzy (ROS 2) | 69 passed | survives |
| noetic (ROS 1) | 67 passed, 2 skipped | n/a |
| ruff | clean | — |

The 2 skips (melodic/noetic) are action detail inspection + status, which require ROS 2 rosbridge features — see #320.

## Related issues

- #317 — Remove hardcoded `action_type_map` (done here)
- #318 — `send_action_goal` timeout bug (websocket manager, out of scope)
- #320 — ROS 1 actionlib support via 5-topic pattern (future)

## PR stack

| Step | PR | Status |
|------|----|--------|
| Step 0: detection + Docker infra | #276 | merged |
| Step 1: connection + robot config | #278 | merged |
| Step 2: nodes | #280 | merged |
| Step 3: topics | #281 | merged |
| Step 4: services | #322 | merged |
| **Step 5: actions** | **this PR** | **open (base: `develop`)** |
| Step 6: parameters | #332 | open |
| Step 7: resources | (not created) | — |
