### PR TITLE
refactor(services): migrate to rosapi_service()/rosapi_type(), add tool tests (step4)

### DIFF
--- a/ros_mcp/tools/services.py
+++ b/ros_mcp/tools/services.py
@@ -4,6 +4,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from ros_mcp.utils.response import _check_response, _safe_get_values
+from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager
 
 
@@ -30,8 +31,8 @@ def register_service_tools(
         """
         message = {
             "op": "call_service",
-            "service": "/rosapi/services",
-            "type": "rosapi_msgs/srv/Services",
+            "service": rosapi_service("services"),
+            "type": rosapi_type("Services"),
             "args": {},
             "id": "get_services_request_1",
         }
@@ -74,8 +75,8 @@ def register_service_tools(
 
         message = {
             "op": "call_service",
-            "service": "/rosapi/service_type",
-            "type": "rosapi_msgs/srv/ServiceType",
+            "service": rosapi_service("service_type"),
+            "type": rosapi_type("ServiceType"),
             "args": {"service": service},
             "id": f"get_service_type_request_{service.replace('/', '_')}",
         }
@@ -134,8 +135,8 @@ def register_service_tools(
             # First get the service type
             type_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_type",
-                "type": "rosapi_msgs/srv/ServiceType",
+                "service": rosapi_service("service_type"),
+                "type": rosapi_type("ServiceType"),
                 "args": {"service": service},
                 "id": f"get_service_type_{service.replace('/', '_')}",
             }
@@ -157,8 +158,8 @@ def register_service_tools(
             # Get request details
             request_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_request_details",
-                "type": "rosapi_msgs/srv/ServiceRequestDetails",
+                "service": rosapi_service("service_request_details"),
+                "type": rosapi_type("ServiceRequestDetails"),
                 "args": {"type": result["type"]},
                 "id": f"get_service_details_request_{result['type'].replace('/', '_')}",
             }
@@ -179,8 +180,8 @@ def register_service_tools(
             # Get response details
             response_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_response_details",
-                "type": "rosapi_msgs/srv/ServiceResponseDetails",
+                "service": rosapi_service("service_response_details"),
+                "type": rosapi_type("ServiceResponseDetails"),
                 "args": {"type": result["type"]},
                 "id": f"get_service_details_response_{result['type'].replace('/', '_')}",
             }
@@ -201,8 +202,8 @@ def register_service_tools(
             # Get service providers
             provider_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_node",
-                "type": "rosapi_msgs/srv/ServiceNode",
+                "service": rosapi_service("service_node"),
+                "type": rosapi_type("ServiceNode"),
                 "args": {"service": service},
                 "id": f"get_service_providers_request_{service.replace('/', '_')}",
             }

--- a/tests/integration/scripts/run-services-tests.sh
+++ b/tests/integration/scripts/run-services-tests.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Run services integration tests against a specific ROS distro.
-# Usage: ./tests/integration/scripts/run-services-tests.sh <distro>
-exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" services

--- a/tests/integration/scripts/run-services-tests.sh
+++ b/tests/integration/scripts/run-services-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run services integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-services-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" services

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -91,16 +91,24 @@ class TestCallService:
         assert result["success"] is True
 
     def test_call_spawn_turtle(self, tools):
-        """call_service for /spawn should create a new turtle."""
+        """call_service for /spawn should create a new turtle (cleaned up after)."""
         turtle_name = f"test_turtle_{int(time.time_ns())}"
-        type_result = tools["get_service_type"](service="/spawn")
-        spawn_type = type_result["type"]
-        result = tools["call_service"](
-            service_name="/spawn",
-            service_type=spawn_type,
-            request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
-        )
-        assert result["success"] is True
+        spawn_type = tools["get_service_type"](service="/spawn")["type"]
+        try:
+            result = tools["call_service"](
+                service_name="/spawn",
+                service_type=spawn_type,
+                request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
+            )
+            assert result["success"] is True
+        finally:
+            # Remove the spawned turtle so state doesn't leak across tests.
+            kill_type = tools["get_service_type"](service="/kill")["type"]
+            tools["call_service"](
+                service_name="/kill",
+                service_type=kill_type,
+                request={"name": turtle_name},
+            )
 
     def test_call_nonexistent_service(self, tools):
         """call_service for a nonexistent service should return an error."""

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -80,9 +80,18 @@ class TestGetServiceDetails:
 class TestCallService:
     """Verify call_service MCP tool can call a live service."""
 
+    def test_call_clear(self, tools):
+        """call_service for /clear should succeed (clears drawing traces)."""
+        type_result = tools["get_service_type"](service="/clear")
+        result = tools["call_service"](
+            service_name="/clear",
+            service_type=type_result["type"],
+            request={},
+        )
+        assert result["success"] is True
+
     def test_call_spawn_turtle(self, tools):
         """call_service for /spawn should create a new turtle."""
-        # Use a unique name to avoid conflicts across test runs
         turtle_name = f"test_turtle_{int(time.time_ns())}"
         type_result = tools["get_service_type"](service="/spawn")
         spawn_type = type_result["type"]
@@ -92,3 +101,12 @@ class TestCallService:
             request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
         )
         assert result["success"] is True
+
+    def test_call_nonexistent_service(self, tools):
+        """call_service for a nonexistent service should return an error."""
+        result = tools["call_service"](
+            service_name="/this_service_does_not_exist",
+            service_type="std_srvs/srv/Empty",
+            request={},
+        )
+        assert result["success"] is False

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,0 +1,94 @@
+"""Integration tests for service tools.
+
+These tests call the actual MCP tool functions (get_services, get_service_type,
+get_service_details, call_service) against a live rosbridge container.
+"""
+
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+class TestGetServices:
+    """Verify get_services MCP tool returns the service list."""
+
+    def test_returns_services(self, tools):
+        """get_services should return services and service_count."""
+        result = tools["get_services"]()
+        assert "services" in result
+        assert "service_count" in result
+        assert result["service_count"] > 0
+        assert result["service_count"] == len(result["services"])
+
+    def test_includes_rosapi_services(self, tools):
+        """rosapi services should be present (rosapi node is running)."""
+        result = tools["get_services"]()
+        services = result["services"]
+        assert any("nodes" in s for s in services), f"nodes service not in {services}"
+
+    def test_includes_turtlesim_services(self, tools):
+        """turtlesim services like /clear or /spawn should be present."""
+        result = tools["get_services"]()
+        services = result["services"]
+        assert any("spawn" in s for s in services), f"spawn not in {services}"
+
+
+class TestGetServiceType:
+    """Verify get_service_type MCP tool returns the service type."""
+
+    def test_known_service_type(self, tools):
+        """get_service_type for a turtlesim service should return a type string."""
+        result = tools["get_service_type"](service="/kill")
+        assert "type" in result
+        assert len(result["type"]) > 0
+
+    def test_empty_service_returns_error(self, tools):
+        """get_service_type with empty string should return error."""
+        result = tools["get_service_type"](service="")
+        assert "error" in result
+
+    def test_whitespace_service_returns_error(self, tools):
+        """get_service_type with whitespace should return error."""
+        result = tools["get_service_type"](service="   ")
+        assert "error" in result
+
+
+class TestGetServiceDetails:
+    """Verify get_service_details MCP tool returns full service definition."""
+
+    def test_spawn_details(self, tools):
+        """get_service_details for /spawn should return request/response fields."""
+        result = tools["get_service_details"](service="/spawn")
+        assert result["service"] == "/spawn"
+        assert len(result["type"]) > 0
+        assert "request" in result
+        assert "response" in result
+
+    def test_empty_service_returns_error(self, tools):
+        """get_service_details with empty string should return error."""
+        result = tools["get_service_details"](service="")
+        assert "error" in result
+
+    def test_whitespace_service_returns_error(self, tools):
+        """get_service_details with whitespace should return error."""
+        result = tools["get_service_details"](service="   ")
+        assert "error" in result
+
+
+class TestCallService:
+    """Verify call_service MCP tool can call a live service."""
+
+    def test_call_spawn_turtle(self, tools):
+        """call_service for /spawn should create a new turtle."""
+        # Use a unique name to avoid conflicts across test runs
+        turtle_name = f"test_turtle_{int(time.time_ns())}"
+        type_result = tools["get_service_type"](service="/spawn")
+        spawn_type = type_result["type"]
+        result = tools["call_service"](
+            service_name="/spawn",
+            service_type=spawn_type,
+            request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
+        )
+        assert result["success"] is True


### PR DESCRIPTION
## Summary

Step 4 of 7 — rebased onto `develop` after step 3 (#281) was squash-merged.

- Replace 12 hardcoded `/rosapi/` strings in `services.py` (6 service paths + 6 type strings) with `rosapi_service()`/`rosapi_type()`
- Integration tests call actual MCP tools (`get_services`, `get_service_type`, `get_service_details`, `call_service`) directly
- Tests cover happy paths and negative paths (empty/whitespace input, nonexistent service)

## Changes

- **`ros_mcp/tools/services.py`** — import helpers, replace 12 hardcoded strings
- **`tests/integration/test_services.py`** — 12 tests; `test_call_spawn_turtle` kills the spawned turtle in a `finally` so state doesn't leak

## Testing

12 tests pass on all 4 distros (melodic, noetic, humble, jazzy), zero skips.

## PR stack

| Step | PR | Status |
|------|----|--------|
| Step 0: detection + Docker infra | #276 | merged |
| Step 1: connection + robot config | #278 | merged |
| Step 2: nodes | #280 | merged |
| Step 3: topics | #281 | merged |
| **Step 4: services** | **this PR** | **open (base: `develop`)** |
| Step 5: actions | #321 | open |
| Step 6: parameters | (not created) | — |
| Step 7: resources | (not created) | — |

_Replaces #316 which was merged to the wrong base branch._
