### PR TITLE
docs: fix example README typos

### DIFF
--- a/examples/5_docker_turtlesim/README.md
+++ b/examples/5_docker_turtlesim/README.md
@@ -55,7 +55,7 @@ docker compose build --no-cache turtlesim
 The easiest way to launch turtlesim with proper X11 setup:
 
 ```bash
-./scrips/launch.sh
+./scripts/launch.sh
 ```
 
 This script automatically detects your OS and handles all platform-specific X11 configuration. It will:
@@ -105,7 +105,7 @@ docker exec -it ros2-turtlesim bash
 Once inside the container, you can manually launch turtle teleop to control the turtle:
 
 ```bash
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 ros2 run turtlesim turtle_teleop_key
 ```
 
@@ -261,7 +261,7 @@ If the automatic launch isn't working or you prefer to launch turtlesim manually
 docker exec -it ros2-turtlesim bash
 
 # Source ROS2 environment
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # Start turtlesim in one terminal
 ros2 run turtlesim turtlesim_node
@@ -283,7 +283,7 @@ In a separate terminal, you can inspect the ROS2 topics:
 docker exec -it ros2-turtlesim bash
 
 # Source ROS2 environment
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # List all topics
 ros2 topic list

--- a/examples/6_chatgpt/README.md
+++ b/examples/6_chatgpt/README.md
@@ -6,7 +6,7 @@
 
 ### Prepare host machine (MCP Server)
 
-* Installation of ChatGPT Desktop. Download [here](chatgpt.com/download) or Microsoft Store.
+* Installation of ChatGPT Desktop. Download [here](https://chatgpt.com/download) or Microsoft Store.
 * Installation of WSL (Linux) or a terminal on macOS.
 
 > 💡 **macOS Users**: You can run the MCP server and ngrok directly on macOS without WSL. For ROS2, use Docker (see [5_docker_turtlesim](../5_docker_turtlesim/) for a ready-made container) since ROS2 is not natively available on macOS.
@@ -272,7 +272,7 @@ cd ros-mcp-server
 	```
 	Or you can also launch:
 	```bash
-	launch_mcp_tunnel_.sh
+	launch_mcp_tunnel.sh
 	```
  	</details>
 

--- a/examples/7_cursor/README.md
+++ b/examples/7_cursor/README.md
@@ -12,7 +12,7 @@
 ### Prepare target robot (ROS)
 
 * Installation of Ubuntu or WSL (Windows Subsystem for Linux) on Windows.
-* Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow, this tutorial. See [here](https://wiki.ros.org/ROS/Tutorials).
+* Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow this tutorial. See [here](https://wiki.ros.org/ROS/Tutorials).
 
 # Tutorial
 


### PR DESCRIPTION
Fixes #287

Changes:
- `./scrips/launch.sh` -> `./scripts/launch.sh` in `examples/5_docker_turtlesim/README.md` (1 occurrence(s))
- `source /opt/ros/${ROS_DISTRO}$/setup.bash` -> `source /opt/ros/${ROS_DISTRO}/setup.bash` in `examples/5_docker_turtlesim/README.md` (3 occurrence(s))
- `[here](chatgpt.com/download)` -> `[here](https://chatgpt.com/download)` in `examples/6_chatgpt/README.md` (1 occurrence(s))
- `launch_mcp_tunnel_.sh` -> `launch_mcp_tunnel.sh` in `examples/6_chatgpt/README.md` (1 occurrence(s))
- `follow, this tutorial` -> `follow this tutorial` in `examples/7_cursor/README.md` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
