### PR TITLE
refactor(parameters): migrate to rosapi_service()/rosapi_type(), add tool tests (step6)

### DIFF
--- a/ros_mcp/tools/parameters.py
+++ b/ros_mcp/tools/parameters.py
@@ -283,6 +283,11 @@ def register_parameter_tools(
 
         Note: This uses get_param internally (via _safe_check_parameter_exists) to avoid
         crashes in rosapi_node when checking for non-existent parameters.
+
+        Limitation: existence is inferred from the parameter's value because the
+        rosbridge ROS 1 get_param API has no separate "exists" signal. A parameter
+        whose value is an empty string or the literal string "null" is therefore
+        reported as not existing (false negative).
         """
         if not name or not name.strip():
             return {"error": "Parameter name cannot be empty"}
@@ -365,7 +370,7 @@ def register_parameter_tools(
                 # success, so when "successful" is absent inside values, fall back to
                 # the top-level "result" field.
                 if "successful" in result_data:
-                    successful = result_data["successful"]
+                    successful = bool(result_data["successful"])
                 else:
                     successful = bool(response.get("result"))
                 reason = result_data.get("reason", "")

--- a/ros_mcp/tools/parameters.py
+++ b/ros_mcp/tools/parameters.py
@@ -4,6 +4,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from ros_mcp.utils.response import _extract_error
+from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager
 
 
@@ -28,8 +29,8 @@ def _safe_check_parameter_exists(
 
     message = {
         "op": "call_service",
-        "service": "/rosapi/get_param",
-        "type": "rosapi_msgs/srv/GetParam",
+        "service": rosapi_service("get_param"),
+        "type": rosapi_type("GetParam"),
         "args": {"name": name},
         "id": f"check_param_exists_{name.replace('/', '_').replace(':', '_')}",
     }
@@ -194,8 +195,8 @@ def register_parameter_tools(
 
         message = {
             "op": "call_service",
-            "service": "/rosapi/set_param",
-            "type": "rosapi_msgs/srv/SetParam",
+            "service": rosapi_service("set_param"),
+            "type": rosapi_type("SetParam"),
             "args": {"name": name, "value": value},
             "id": f"set_param_{name.replace('/', '_').replace(':', '_')}",
         }
@@ -328,8 +329,8 @@ def register_parameter_tools(
 
         message = {
             "op": "call_service",
-            "service": "/rosapi/delete_param",
-            "type": "rosapi_msgs/srv/DeleteParam",
+            "service": rosapi_service("delete_param"),
+            "type": rosapi_type("DeleteParam"),
             "args": {"name": name},
             "id": f"delete_param_{name.replace('/', '_').replace(':', '_')}",
         }
@@ -539,8 +540,8 @@ def register_parameter_tools(
         if value_response is None:
             value_message = {
                 "op": "call_service",
-                "service": "/rosapi/get_param",
-                "type": "rosapi_msgs/srv/GetParam",
+                "service": rosapi_service("get_param"),
+                "type": rosapi_type("GetParam"),
                 "args": {"name": name},
                 "id": f"get_param_details_{name.replace('/', '_').replace(':', '_')}",
             }
@@ -589,7 +590,7 @@ def register_parameter_tools(
         # Get parameter type
         type_message = {
             "op": "call_service",
-            "service": "/rosapi/describe_parameters",
+            "service": rosapi_service("describe_parameters"),
             "type": "rcl_interfaces/DescribeParameters",
             "args": {"names": [name]},
             "id": f"describe_param_details_{name.replace('/', '_').replace(':', '_')}",

--- a/ros_mcp/tools/parameters.py
+++ b/ros_mcp/tools/parameters.py
@@ -20,12 +20,16 @@ def _safe_check_parameter_exists(
     """
 
     def _is_empty_value(value: str) -> bool:
-        """Check if a parameter value is effectively empty."""
+        """Check if a parameter value indicates the parameter does not exist."""
         if not value:
             return True
-        # Strip quotes (handles cases like '""' which represents empty string)
+        # Strip quotes (handles '""' which represents empty string)
         stripped = value.strip('"').strip("'")
-        return not stripped or stripped == ""
+        if not stripped:
+            return True
+        # ROS 1 rosbridge get_param returns the literal JSON value `null` (string "null")
+        # for missing parameters, with result=true. Treat as nonexistent.
+        return stripped == "null"
 
     message = {
         "op": "call_service",
@@ -357,7 +361,13 @@ def register_parameter_tools(
         if response and "values" in response:
             result_data = response["values"]
             if isinstance(result_data, dict):
-                successful = result_data.get("successful", False)
+                # ROS 1 rosapi delete_param returns {"values": {}, "result": true} on
+                # success, so when "successful" is absent inside values, fall back to
+                # the top-level "result" field.
+                if "successful" in result_data:
+                    successful = result_data["successful"]
+                else:
+                    successful = bool(response.get("result"))
                 reason = result_data.get("reason", "")
                 return {
                     "name": name,

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -123,9 +123,11 @@ class TestDeleteParameter:
     def test_delete_round_trip(self, tools):
         if get_ros_version() == RosVersion.ROS2:
             pytest.skip(
-                "ROS 2 parameters are per-node; turtlesim doesn't allow deleting its "
-                "own params at runtime. ROS 2 deletion is covered by the existence "
-                "check in TestHasParameter and the set restore in TestSetParameter."
+                "ROS 2 delete-success is not exercisable against this setup: turtlesim "
+                "silently drops undeclared params (set 'succeeds' but nothing persists "
+                "to delete), and deleting a declared param crashes the rosapi node. The "
+                "testable ROS 2 delete paths (nonexistent -> unsuccessful, empty name -> "
+                "error) are covered by the other tests in this class."
             )
         name = f"/ros_mcp_test_delete_{int(time.time_ns())}"
         tools["set_parameter"](name=name, value="1")

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -1,0 +1,195 @@
+"""Integration tests for parameter tools.
+
+These tests call the actual MCP tool functions (get_parameter, set_parameter,
+has_parameter, delete_parameter, get_parameters, get_parameter_details)
+against a live rosbridge container.
+
+Parameter semantics differ across ROS versions:
+- ROS 1 (melodic/noetic): global parameter server, slash-separated names
+  (e.g. /turtlesim/background_r). The test seeds a known parameter via
+  set_parameter before reading.
+- ROS 2 (humble/jazzy): per-node parameters keyed "node:name" through
+  rosbridge (e.g. /turtlesim:background_r). turtlesim populates background_r/g/b
+  on launch.
+
+get_parameter_details uses rcl_interfaces/DescribeParameters and is ROS 2-only.
+"""
+
+import time
+
+import pytest
+
+from ros_mcp.utils.rosapi_types import RosVersion, get_ros_version
+
+pytestmark = [pytest.mark.integration]
+
+
+_PARAMS = {
+    RosVersion.ROS1: {
+        "read_name": "/turtlesim/background_r",
+        "seed_name": "/ros_mcp_test_param",
+        "seed_value": "42",
+    },
+    RosVersion.ROS2: {
+        "read_name": "/turtlesim:background_r",
+        "seed_name": "/turtlesim:background_r",
+        "seed_value": "100",
+    },
+}
+
+
+def _params_for_current_version() -> dict:
+    version = get_ros_version()
+    return _PARAMS[version]
+
+
+@pytest.fixture
+def params():
+    return _params_for_current_version()
+
+
+@pytest.fixture
+def ros1_seeded_param(tools, params):
+    """On ROS 1, set a known parameter before the test and clean it up after."""
+    if get_ros_version() != RosVersion.ROS1:
+        yield params
+        return
+    tools["set_parameter"](name=params["seed_name"], value=params["seed_value"])
+    yield params
+    tools["delete_parameter"](name=params["seed_name"])
+
+
+class TestGetParameter:
+    def test_returns_value_for_known_parameter(self, tools, ros1_seeded_param):
+        target = (
+            ros1_seeded_param["seed_name"]
+            if get_ros_version() == RosVersion.ROS1
+            else ros1_seeded_param["read_name"]
+        )
+        result = tools["get_parameter"](name=target)
+        assert "value" in result
+        assert result.get("successful", True) is True
+        assert str(result["value"]).strip() != ""
+
+    def test_empty_name_returns_error(self, tools):
+        result = tools["get_parameter"](name="")
+        assert "error" in result
+
+    def test_whitespace_name_returns_error(self, tools):
+        result = tools["get_parameter"](name="   ")
+        assert "error" in result
+
+
+class TestSetParameter:
+    def test_set_succeeds(self, tools, params):
+        unique_name = (
+            f"/ros_mcp_test_set_{int(time.time_ns())}"
+            if get_ros_version() == RosVersion.ROS1
+            else params["seed_name"]
+        )
+        result = tools["set_parameter"](name=unique_name, value="7")
+        assert result.get("successful") is True
+        if get_ros_version() == RosVersion.ROS1:
+            tools["delete_parameter"](name=unique_name)
+
+    def test_empty_name_returns_error(self, tools):
+        result = tools["set_parameter"](name="", value="1")
+        assert "error" in result
+
+
+class TestHasParameter:
+    def test_existing_parameter(self, tools, ros1_seeded_param):
+        target = (
+            ros1_seeded_param["seed_name"]
+            if get_ros_version() == RosVersion.ROS1
+            else ros1_seeded_param["read_name"]
+        )
+        result = tools["has_parameter"](name=target)
+        assert result["exists"] is True
+
+    def test_nonexistent_parameter(self, tools):
+        if get_ros_version() == RosVersion.ROS1:
+            pytest.skip(
+                "On ROS 1, _safe_check_parameter_exists uses get_param which returns a "
+                "non-empty value for unknown params (e.g. '0' or empty string treated as "
+                "non-empty), causing has_parameter to incorrectly report exists=True. "
+                "This is a known tool limitation on ROS 1."
+            )
+        result = tools["has_parameter"](name="/ros_mcp_does_not_exist_xyz")
+        assert result["exists"] is False
+
+    def test_empty_name_returns_error(self, tools):
+        result = tools["has_parameter"](name="")
+        assert "error" in result
+
+
+class TestDeleteParameter:
+    def test_delete_round_trip(self, tools):
+        if get_ros_version() == RosVersion.ROS2:
+            pytest.skip(
+                "Deleting turtlesim parameters on ROS 2 leaves the node in a bad state; "
+                "covered by set_parameter test instead"
+            )
+        pytest.skip(
+            "On ROS 1, the delete_param rosapi service returns successful=False even when "
+            "deletion succeeds (rosbridge response format mismatch). This is a known tool "
+            "limitation on ROS 1 — the delete_param response does not include a 'successful' "
+            "field and the code defaults to False. Covered by set_parameter test instead."
+        )
+        name = f"/ros_mcp_test_delete_{int(time.time_ns())}"
+        tools["set_parameter"](name=name, value="1")
+        assert tools["has_parameter"](name=name)["exists"] is True
+        result = tools["delete_parameter"](name=name)
+        assert result.get("successful") is True
+        assert tools["has_parameter"](name=name)["exists"] is False
+
+    def test_nonexistent_returns_unsuccessful(self, tools):
+        result = tools["delete_parameter"](name="/ros_mcp_does_not_exist_xyz")
+        assert result.get("successful") is False
+
+    def test_empty_name_returns_error(self, tools):
+        result = tools["delete_parameter"](name="")
+        assert "error" in result
+
+
+class TestGetParameters:
+    def test_returns_list_for_known_node(self, tools):
+        if get_ros_version() == RosVersion.ROS1:
+            pytest.skip(
+                "get_parameters calls node/list_parameters (rcl_interfaces/srv/ListParameters), "
+                "which is a ROS 2-only per-node service. On ROS 1 there is no equivalent "
+                "rosbridge mechanism."
+            )
+        node = "turtlesim"
+        result = tools["get_parameters"](node_name=node)
+        assert "parameters" in result
+        assert "parameter_count" in result
+        assert isinstance(result["parameters"], list)
+
+    def test_empty_node_returns_error(self, tools):
+        result = tools["get_parameters"](node_name="")
+        assert "error" in result
+
+
+class TestGetParameterDetails:
+    def test_returns_details_for_known_parameter(self, tools, ros1_seeded_param):
+        if get_ros_version() == RosVersion.ROS1:
+            pytest.skip(
+                "get_parameter_details relies on rcl_interfaces/DescribeParameters (ROS 2 only)"
+            )
+        result = tools["get_parameter_details"](name=ros1_seeded_param["read_name"])
+        assert result["exists"] is True
+        assert "value" in result
+        assert "type" in result
+
+    def test_nonexistent_returns_error_response(self, tools):
+        if get_ros_version() == RosVersion.ROS1:
+            pytest.skip(
+                "get_parameter_details relies on rcl_interfaces/DescribeParameters (ROS 2 only)"
+            )
+        result = tools["get_parameter_details"](name="/turtlesim:does_not_exist")
+        assert result["exists"] is False
+
+    def test_empty_name_returns_error(self, tools):
+        result = tools["get_parameter_details"](name="")
+        assert "error" in result

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -12,7 +12,9 @@ Parameter semantics differ across ROS versions:
   rosbridge (e.g. /turtlesim:background_r). turtlesim populates background_r/g/b
   on launch.
 
-get_parameter_details uses rcl_interfaces/DescribeParameters and is ROS 2-only.
+get_parameters relies on rcl_interfaces/srv/ListParameters and is ROS 2-only;
+on ROS 1 the tool returns a graceful "service does not exist" error, which the
+test asserts directly.
 """
 
 import time
@@ -109,13 +111,6 @@ class TestHasParameter:
         assert result["exists"] is True
 
     def test_nonexistent_parameter(self, tools):
-        if get_ros_version() == RosVersion.ROS1:
-            pytest.skip(
-                "On ROS 1, _safe_check_parameter_exists uses get_param which returns a "
-                "non-empty value for unknown params (e.g. '0' or empty string treated as "
-                "non-empty), causing has_parameter to incorrectly report exists=True. "
-                "This is a known tool limitation on ROS 1."
-            )
         result = tools["has_parameter"](name="/ros_mcp_does_not_exist_xyz")
         assert result["exists"] is False
 
@@ -126,18 +121,11 @@ class TestHasParameter:
 
 class TestDeleteParameter:
     def test_delete_round_trip(self, tools):
-        version = get_ros_version()
-        if version == RosVersion.ROS2:
+        if get_ros_version() == RosVersion.ROS2:
             pytest.skip(
-                "Deleting turtlesim parameters on ROS 2 leaves the node in a bad state; "
-                "covered by set_parameter test instead"
-            )
-        if version == RosVersion.ROS1:
-            pytest.skip(
-                "On ROS 1, the delete_param rosapi service returns successful=False even when "
-                "deletion succeeds (rosbridge response format mismatch). The delete_param "
-                "response does not include a 'successful' field and the code defaults to False. "
-                "Covered by set_parameter test instead."
+                "ROS 2 parameters are per-node; turtlesim doesn't allow deleting its "
+                "own params at runtime. ROS 2 deletion is covered by the existence "
+                "check in TestHasParameter and the set restore in TestSetParameter."
             )
         name = f"/ros_mcp_test_delete_{int(time.time_ns())}"
         tools["set_parameter"](name=name, value="1")
@@ -157,14 +145,14 @@ class TestDeleteParameter:
 
 class TestGetParameters:
     def test_returns_list_for_known_node(self, tools):
+        result = tools["get_parameters"](node_name="turtlesim")
         if get_ros_version() == RosVersion.ROS1:
-            pytest.skip(
-                "get_parameters calls node/list_parameters (rcl_interfaces/srv/ListParameters), "
-                "which is a ROS 2-only per-node service. On ROS 1 there is no equivalent "
-                "rosbridge mechanism."
-            )
-        node = "turtlesim"
-        result = tools["get_parameters"](node_name=node)
+            # get_parameters relies on rcl_interfaces/srv/ListParameters which only
+            # exists on ROS 2. The tool documents "Works only with ROS 2" and returns
+            # a graceful error pointing at the missing per-node service.
+            assert "error" in result
+            assert "list_parameters" in result["error"]
+            return
         assert "parameters" in result
         assert "parameter_count" in result
         assert isinstance(result["parameters"], list)
@@ -176,21 +164,20 @@ class TestGetParameters:
 
 class TestGetParameterDetails:
     def test_returns_details_for_known_parameter(self, tools, ros1_seeded_param):
-        if get_ros_version() == RosVersion.ROS1:
-            pytest.skip(
-                "get_parameter_details relies on rcl_interfaces/DescribeParameters (ROS 2 only)"
-            )
-        result = tools["get_parameter_details"](name=ros1_seeded_param["read_name"])
+        # On ROS 1, the describe_parameters call fails internally but the tool
+        # falls back to type inference from the value, so the test passes on both
+        # versions. On ROS 2, describe_parameters supplies the type.
+        result = tools["get_parameter_details"](name=ros1_seeded_param["existing_name"])
         assert result["exists"] is True
         assert "value" in result
         assert "type" in result
 
     def test_nonexistent_returns_error_response(self, tools):
         if get_ros_version() == RosVersion.ROS1:
-            pytest.skip(
-                "get_parameter_details relies on rcl_interfaces/DescribeParameters (ROS 2 only)"
-            )
-        result = tools["get_parameter_details"](name="/turtlesim:does_not_exist")
+            name = "/ros_mcp_definitely_does_not_exist"
+        else:
+            name = "/turtlesim:does_not_exist"
+        result = tools["get_parameter_details"](name=name)
         assert result["exists"] is False
 
     def test_empty_name_returns_error(self, tools):

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -29,11 +29,15 @@ _PARAMS = {
         "read_name": "/turtlesim/background_r",
         "seed_name": "/ros_mcp_test_param",
         "seed_value": "42",
+        # On ROS 1, the only param we know exists post-fixture is the one we seed.
+        "existing_name": "/ros_mcp_test_param",
     },
     RosVersion.ROS2: {
         "read_name": "/turtlesim:background_r",
         "seed_name": "/turtlesim:background_r",
         "seed_value": "100",
+        # On ROS 2, turtlesim populates background_r on launch.
+        "existing_name": "/turtlesim:background_r",
     },
 }
 
@@ -61,14 +65,9 @@ def ros1_seeded_param(tools, params):
 
 class TestGetParameter:
     def test_returns_value_for_known_parameter(self, tools, ros1_seeded_param):
-        target = (
-            ros1_seeded_param["seed_name"]
-            if get_ros_version() == RosVersion.ROS1
-            else ros1_seeded_param["read_name"]
-        )
-        result = tools["get_parameter"](name=target)
+        result = tools["get_parameter"](name=ros1_seeded_param["existing_name"])
         assert "value" in result
-        assert result.get("successful", True) is True
+        assert result.get("successful") is True
         assert str(result["value"]).strip() != ""
 
     def test_empty_name_returns_error(self, tools):
@@ -82,15 +81,22 @@ class TestGetParameter:
 
 class TestSetParameter:
     def test_set_succeeds(self, tools, params):
-        unique_name = (
-            f"/ros_mcp_test_set_{int(time.time_ns())}"
-            if get_ros_version() == RosVersion.ROS1
-            else params["seed_name"]
-        )
-        result = tools["set_parameter"](name=unique_name, value="7")
-        assert result.get("successful") is True
-        if get_ros_version() == RosVersion.ROS1:
+        version = get_ros_version()
+        if version == RosVersion.ROS1:
+            unique_name = f"/ros_mcp_test_set_{int(time.time_ns())}"
+            result = tools["set_parameter"](name=unique_name, value="7")
+            assert result.get("successful") is True
             tools["delete_parameter"](name=unique_name)
+            return
+        # ROS 2: mutating turtlesim's params, so capture and restore.
+        target = params["seed_name"]
+        original = tools["get_parameter"](name=target).get("value")
+        try:
+            result = tools["set_parameter"](name=target, value="7")
+            assert result.get("successful") is True
+        finally:
+            if original is not None:
+                tools["set_parameter"](name=target, value=str(original))
 
     def test_empty_name_returns_error(self, tools):
         result = tools["set_parameter"](name="", value="1")
@@ -99,12 +105,7 @@ class TestSetParameter:
 
 class TestHasParameter:
     def test_existing_parameter(self, tools, ros1_seeded_param):
-        target = (
-            ros1_seeded_param["seed_name"]
-            if get_ros_version() == RosVersion.ROS1
-            else ros1_seeded_param["read_name"]
-        )
-        result = tools["has_parameter"](name=target)
+        result = tools["has_parameter"](name=ros1_seeded_param["existing_name"])
         assert result["exists"] is True
 
     def test_nonexistent_parameter(self, tools):

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -28,14 +28,12 @@ pytestmark = [pytest.mark.integration]
 
 _PARAMS = {
     RosVersion.ROS1: {
-        "read_name": "/turtlesim/background_r",
         "seed_name": "/ros_mcp_test_param",
         "seed_value": "42",
         # On ROS 1, the only param we know exists post-fixture is the one we seed.
         "existing_name": "/ros_mcp_test_param",
     },
     RosVersion.ROS2: {
-        "read_name": "/turtlesim:background_r",
         "seed_name": "/turtlesim:background_r",
         "seed_value": "100",
         # On ROS 2, turtlesim populates background_r on launch.

--- a/tests/integration/test_parameters.py
+++ b/tests/integration/test_parameters.py
@@ -125,17 +125,19 @@ class TestHasParameter:
 
 class TestDeleteParameter:
     def test_delete_round_trip(self, tools):
-        if get_ros_version() == RosVersion.ROS2:
+        version = get_ros_version()
+        if version == RosVersion.ROS2:
             pytest.skip(
                 "Deleting turtlesim parameters on ROS 2 leaves the node in a bad state; "
                 "covered by set_parameter test instead"
             )
-        pytest.skip(
-            "On ROS 1, the delete_param rosapi service returns successful=False even when "
-            "deletion succeeds (rosbridge response format mismatch). This is a known tool "
-            "limitation on ROS 1 — the delete_param response does not include a 'successful' "
-            "field and the code defaults to False. Covered by set_parameter test instead."
-        )
+        if version == RosVersion.ROS1:
+            pytest.skip(
+                "On ROS 1, the delete_param rosapi service returns successful=False even when "
+                "deletion succeeds (rosbridge response format mismatch). The delete_param "
+                "response does not include a 'successful' field and the code defaults to False. "
+                "Covered by set_parameter test instead."
+            )
         name = f"/ros_mcp_test_delete_{int(time.time_ns())}"
         tools["set_parameter"](name=name, value="1")
         assert tools["has_parameter"](name=name)["exists"] is True


### PR DESCRIPTION
## Summary

Step 6 in the rosapi-migration stack (master plan: `docs/superpowers/plans/2026-03-21-split-pr272-integration-tests.md`). Picks up the **parameters** half that was deferred from step5.

- **Migrate `parameters.py`**: replace 5 hardcoded `/rosapi/` service paths and 4 hardcoded `rosapi_msgs/srv/*` type strings with `rosapi_service()` / `rosapi_type()` helper calls. The `rcl_interfaces/DescribeParameters` type at the `describe_parameters` call site is intentionally left as a literal — it isn't a `rosapi_msgs/srv/*` type, so the helper doesn't apply.
- **Fix two real ROS 1 bugs surfaced by the new tests**:
  1. `_safe_check_parameter_exists` (used by `has_parameter`, `set_parameter`, `delete_parameter`, `get_parameter_details`) treated the rosbridge ROS 1 sentinel `value="null"` as a legitimate value, so every missing param was reported as existing. Now treats `"null"` as the missing sentinel.
  2. `delete_parameter` read `successful` out of `values` with a `False` default, but rosapi ROS 1 returns `{"values": {}, "result": true}` on success — so every successful ROS 1 delete reported `successful=False`. Now falls back to the top-level `result` field when `successful` is absent from `values`.
- **Add `tests/integration/test_parameters.py`**: 16 tests across 6 classes covering `get_parameter`, `set_parameter`, `has_parameter`, `delete_parameter`, `get_parameters`, `get_parameter_details`. Uses the existing `tools` fixture from `conftest.py` plus a `_PARAMS` dict keyed by `RosVersion` to handle ROS 1 (global server, slash-separated names) vs. ROS 2 (per-node, colon-separated names) — same pattern as `test_actions.py:_ACTIONS`.

## Test results

Parameters module (`test_parameters.py`), verified locally against live rosbridge containers:

| Distro | Pass | Skip | Fail |
|--------|------|------|------|
| melodic | 16 | 0 | 0 |
| noetic | 16 | 0 | 0 |
| humble | 15 | 1 | 0 |
| jazzy | 15 | 1 | 0 |

The full integration suite runs green in CI on all four distros. The 1 ROS 2 skip is `test_delete_round_trip`. Verified against a live container, ROS 2 delete-success can't be exercised here: turtlesim silently drops undeclared params (set reports success but nothing persists to delete) and deleting a declared param crashes the rosapi node. The testable ROS 2 delete paths (nonexistent -> unsuccessful, empty name -> error) remain covered by the other tests in `TestDeleteParameter`.

## Stack position

```
develop ← #281 step3 ← #322 step4 ← #321 step5 ← #332 step6
```

## Test plan

- [x] CI green on melodic, noetic, humble, jazzy
- [x] `grep -n '"/rosapi/' ros_mcp/tools/parameters.py` returns no live-code matches
- [x] Confirm the two `parameters.py` response-shape fixes don't change ROS 2 behavior (existing ROS 2 tool tests still pass)



