### PR TITLE
ci: use PR_BOT_TOKEN for gh pr create in sync/merge workflows

### DIFF
--- a/.github/workflows/merge-into-branch.yml
+++ b/.github/workflows/merge-into-branch.yml
@@ -113,7 +113,9 @@ jobs:
       - name: Open conflict-resolution PR
         if: ${{ steps.merge.outputs.conflict == 'true' && !inputs.check_only }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot open PRs when the org disallows Actions from
+          # creating PRs, so use a PAT/App token stored as PR_BOT_TOKEN.
+          GH_TOKEN: ${{ secrets.PR_BOT_TOKEN }}
           SYNC_BRANCH: ${{ steps.sync-branch.outputs.SYNC_BRANCH }}
         run: |
           gh pr create \

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -69,7 +69,9 @@ jobs:
           echo "SYNC_BRANCH=$SYNC_BRANCH" >> "$GITHUB_OUTPUT"
       - name: Create syncing PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot open PRs when the org disallows Actions from
+          # creating PRs, so use a PAT/App token stored as PR_BOT_TOKEN.
+          GH_TOKEN: ${{ secrets.PR_BOT_TOKEN }}
           SYNC_BRANCH: ${{ steps.create-sync-branch.outputs.SYNC_BRANCH }}
         run: |
           gh pr create \


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` is blocked from creating PRs because the `robotmcp` org disables "Allow GitHub Actions to create and approve pull requests" (the repo checkbox is locked by org policy). This makes the `gh pr create` steps fail with *"GitHub Actions is not permitted to create or approve pull requests"*.
- Switch only the **PR-creation** steps to authenticate with a `PR_BOT_TOKEN` secret (a PAT or GitHub App token), which isn't subject to the Actions restriction.

## Changes
- `sync-main-to-develop.yml` → *Create syncing PR*: `GH_TOKEN` now uses `secrets.PR_BOT_TOKEN`.
- `merge-into-branch.yml` → *Open conflict-resolution PR*: `GH_TOKEN` now uses `secrets.PR_BOT_TOKEN`.
- Everything else is unchanged: checkout, push to `develop`, the merge itself, and the read-only "PR already open" guard all keep using `GITHUB_TOKEN`.

## Required setup (before these workflows can create PRs)
Add a repo secret named **`PR_BOT_TOKEN`** (Settings → Secrets and variables → Actions):
- A **classic PAT** with the `repo` scope, **or** a **fine-grained PAT** with *Pull requests: write* on this repo, from an account with write access.
- PRs created by the workflow will be authored by that token's owner; rotate the token before it expires (a GitHub App bot avoids both concerns).

## Test plan
- Both workflows parse as valid YAML (verified locally).
- After merge + secret added: trigger a sync (or a `merge-into-branch` run that conflicts) and confirm the draft PR is created instead of failing at the `gh pr create` step.
