### PR TITLE
docs: fix typo in 2_gemini README prerequisites

### DIFF
--- a/examples/2_gemini/README.md
+++ b/examples/2_gemini/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisite
 - Installation of Gemini-CLI. [https://github.com/google-gemini/gemini-cli]
-- Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow, this toturial [https://wiki.ros.org/ROS/Tutorials]
+- Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow this tutorial [https://wiki.ros.org/ROS/Tutorials]
 - Installation of ROS-MCP-Server except Section II (installation/settings of Claude desktop)  [Installation Guide](../../docs/install/installation.md). For Gemini CLI-specific setup, see the [Gemini CLI setup guide](../../docs/install/clients/gemini-cli.md)
 
 ## Update Gemini CLI MCP settings


### PR DESCRIPTION
## Summary

Fixes the remaining typo reported in #285.

`examples/2_gemini/README.md` line 5: `follow, this toturial` → `follow this tutorial`.

The companion `examples/5_docker_turtlesim/README.md` `./scrips/launch.sh` typo from the same issue is already corrected on `main`, so this PR only covers the gemini README.

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)