### PR TITLE
docs(install): explain macOS zsh -lc / uvx PATH pitfall

### DIFF
--- a/docs/install/clients/claude-desktop.md
+++ b/docs/install/clients/claude-desktop.md
@@ -57,6 +57,8 @@ Add the following to the file:
 }
 ```
 
+> **macOS: "Could not attach to MCP server"?** `zsh -lc` sources `~/.zprofile` but not `~/.zshrc`, where the `uv` installer puts `~/.local/bin` on your `PATH` — so the subprocess can't find `uvx`. Fix it by adding `~/.local/bin` to `~/.zprofile`, or by using the absolute path to `uvx`. See [Troubleshooting](../troubleshooting.md#macos-could-not-attach-to-mcp-server--uvx-not-found).
+
 **Windows (WSL):**
 ```json
 {

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -14,6 +14,38 @@
    ```
 3. **Check your client's logs** for error messages related to MCP server initialization.
 
+## macOS: "Could not attach to MCP server" / `uvx` Not Found
+
+**Symptoms:** On macOS, Claude Desktop reports "Could not attach to MCP server ros-mcp-server", even though `uvx ros-mcp --help` works fine in your terminal.
+
+**Cause:** The default macOS config launches the server with `zsh -lc`, which starts a **login, non-interactive** shell. That sources `~/.zprofile` but **not** `~/.zshrc`. The `uv` installer adds `~/.local/bin` to your `PATH` in `~/.zshrc` only, so the subprocess Claude Desktop spawns can't find `uvx`.
+
+Reproduce the clean-subprocess environment Claude Desktop uses:
+```bash
+env -i HOME="$HOME" USER="$USER" zsh -lc 'which uvx'
+# "uvx not found" → you are hitting this issue
+```
+
+**Solutions** (pick one):
+
+1. **Make `~/.local/bin` available to login shells** — add it to `~/.zprofile` (which `zsh -lc` *does* source):
+   ```bash
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zprofile
+   ```
+   Then fully restart Claude Desktop.
+
+2. **Use the absolute path to `uvx`** in `claude_desktop_config.json` instead of going through a shell. Find it with `which uvx` (usually `~/.local/bin/uvx`):
+   ```json
+   {
+     "mcpServers": {
+       "ros-mcp-server": {
+         "command": "/Users/<you>/.local/bin/uvx",
+         "args": ["ros-mcp", "--transport=stdio"]
+       }
+     }
+   }
+   ```
+
 ## Connection Refused / Cannot Reach Rosbridge
 
 **Symptoms:** "Connection refused", "No valid session ID provided", or timeout errors when trying to interact with ROS.


### PR DESCRIPTION
## Summary

Fixes #310. On macOS, Claude Desktop launches the server with `zsh -lc`, a login + non-interactive shell that sources `~/.zprofile` but **not** `~/.zshrc` — where the `uv` installer puts `~/.local/bin` on `PATH`. So the spawned subprocess can't find `uvx` and fails to attach, even though `uvx ros-mcp --help` works in a normal terminal.

## Changes

- **`docs/install/troubleshooting.md`** — new section "macOS: Could not attach to MCP server / `uvx` Not Found": the reproduce command (`env -i HOME=... zsh -lc 'which uvx'`) and two fixes (add `~/.local/bin` to `~/.zprofile`, or use the absolute `uvx` path).
- **`docs/install/clients/claude-desktop.md`** — short callout under the macOS config block linking to that section.

Docs-only; no code changes.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)