### PR TITLE
refactor(metadata): drop hardcoded action_type_map, derive type from interfaces

### DIFF
--- a/ros_mcp/resources/ros_metadata.py
+++ b/ros_mcp/resources/ros_metadata.py
@@ -585,41 +585,32 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
                 # Get details for each action
                 action_errors = []
                 for action in actions:
-                    # Try to get action type (this may not always work due to rosapi limitations)
+                    # rosapi exposes only interface names, so derive each action's
+                    # type from the registered action interfaces. Match the action's
+                    # final path segment by name, ignoring case and underscores
+                    # (e.g. rotate_absolute ↔ turtlesim/action/RotateAbsolute).
                     action_type = "unknown"
 
-                    # Known action type mappings for common actions
-                    action_type_map = {
-                        "/turtle1/rotate_absolute": "turtlesim/action/RotateAbsolute",
-                        # Add more mappings as needed based on common ROS actions
+                    interfaces_message = {
+                        "op": "call_service",
+                        "service": rosapi_service("interfaces"),
+                        "type": rosapi_type("Interfaces"),
+                        "args": {},
+                        "id": f"get_interfaces_{action.replace('/', '_')}",
                     }
 
-                    if action in action_type_map:
-                        action_type = action_type_map[action]
-                    else:
-                        # Try to derive from interfaces
-                        interfaces_message = {
-                            "op": "call_service",
-                            "service": rosapi_service("interfaces"),
-                            "type": rosapi_type("Interfaces"),
-                            "args": {},
-                            "id": f"get_interfaces_{action.replace('/', '_')}",
-                        }
-
-                        interfaces_response = ws_manager.request(interfaces_message)
-                        iface_vals = _safe_get_values(interfaces_response)
-                        if iface_vals is not None:
-                            interfaces = iface_vals.get("interfaces", [])
-                            action_interfaces = [
-                                iface for iface in interfaces if "/action/" in iface
-                            ]
-
-                            # Try to match based on action name patterns
-                            action_name_part = action.split("/")[-1]
-                            for iface in action_interfaces:
-                                if action_name_part.lower() in iface.lower():
-                                    action_type = iface
-                                    break
+                    interfaces_response = ws_manager.request(interfaces_message)
+                    iface_vals = _safe_get_values(interfaces_response)
+                    if iface_vals is not None:
+                        interfaces = iface_vals.get("interfaces", [])
+                        action_name = action.split("/")[-1].replace("_", "").lower()
+                        for iface in interfaces:
+                            if (
+                                "/action/" in iface
+                                and action_name in iface.replace("_", "").lower()
+                            ):
+                                action_type = iface
+                                break
 
                     action_details[action] = {
                         "type": action_type,

--- a/ros_mcp/resources/ros_metadata.py
+++ b/ros_mcp/resources/ros_metadata.py
@@ -19,12 +19,7 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
 
     @mcp.resource("ros-mcp://ros-metadata/all")
     def get_all_ros_metadata() -> str:
-        """
-        Get all ROS metadata including topics, services, nodes, and parameters.
-
-        Returns:
-            str: JSON string with comprehensive ROS system information
-        """
+        """Topics, services, nodes, parameters, and ROS version as a JSON string."""
         try:
             metadata = {
                 "topics": [],
@@ -161,17 +156,7 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
 
     @mcp.resource("ros-mcp://ros-metadata/nodes/all")
     def get_nodes_details() -> str:
-        """
-        Get comprehensive information about all ROS nodes including their publishers, subscribers, and services.
-
-        Returns:
-            str: JSON string with detailed information about all nodes including:
-                - Node names and details
-                - Publishers for each node
-                - Subscribers for each node
-                - Services provided by each node
-                - Connection counts and statistics
-        """
+        """All nodes with their publishers, subscribers, and services, as a JSON string."""
         try:
             # First get all nodes
             nodes_message = {
@@ -258,15 +243,7 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
 
     @mcp.resource("ros-mcp://ros-metadata/services/all")
     def get_services_details() -> str:
-        """
-        Get comprehensive information about all ROS services including types and providers.
-
-        Returns:
-            str: JSON string with detailed information about all services including:
-                - Service names and types
-                - Provider nodes for each service
-                - Connection counts and statistics
-        """
+        """All services with their types and provider nodes, as a JSON string."""
         try:
             # First get all services
             services_message = {
@@ -373,16 +350,7 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
 
     @mcp.resource("ros-mcp://ros-metadata/topics/all")
     def get_topics_details() -> str:
-        """
-        Get comprehensive information about all ROS topics including publishers, subscribers, and message types.
-
-        Returns:
-            str: JSON string with detailed information about all topics including:
-                - Topic names and types
-                - Publishers for each topic
-                - Subscribers for each topic
-                - Connection counts and statistics
-        """
+        """All topics with their types, publishers, and subscribers, as a JSON string."""
         try:
             # First get all topics
             topics_message = {
@@ -488,15 +456,7 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
 
     @mcp.resource("ros-mcp://ros-metadata/actions/all")
     def get_actions_details() -> str:
-        """
-        Get comprehensive information about all ROS actions including types and available actions.
-
-        Returns:
-            str: JSON string with detailed information about all actions including:
-                - Action names and types
-                - Action status and availability
-                - Connection counts and statistics
-        """
+        """All actions with their types and availability, as a JSON string."""
         try:
             # Check if required action services are available
             required_services = [rosapi_service("action_servers")]

--- a/ros_mcp/resources/ros_metadata.py
+++ b/ros_mcp/resources/ros_metadata.py
@@ -55,9 +55,10 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
                 }
                 with ws_manager:
                     response = ws_manager.request(topics_message)
-                    if response and "values" in response:
-                        topics = response["values"].get("topics", [])
-                        types = response["values"].get("types", [])
+                    values = _safe_get_values(response)
+                    if values is not None:
+                        topics = values.get("topics", [])
+                        types = values.get("types", [])
                         # Handle case where types might be empty or missing
                         if types and len(types) == len(topics):
                             metadata["topics"] = [

--- a/tests/unit/test_ros_metadata_resources.py
+++ b/tests/unit/test_ros_metadata_resources.py
@@ -1,0 +1,82 @@
+"""Unit tests for the ros-metadata MCP resources.
+
+These exercise the resource callables directly with a fake ``mcp`` and a fake
+``ws_manager``, so they need no running rosbridge.
+"""
+
+import json
+
+from ros_mcp.resources.ros_metadata import register_ros_metadata_resources
+
+
+class _FakeMcp:
+    """Captures functions registered via the ``@mcp.resource(uri)`` decorator."""
+
+    def __init__(self):
+        self.resources = {}
+
+    def resource(self, uri):
+        def decorator(fn):
+            self.resources[uri] = fn
+            return fn
+
+        return decorator
+
+
+class _FakeWs:
+    """Minimal stand-in for WebSocketManager: a context manager with ``request``."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.default_timeout = 2.0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def request(self, message, timeout=None):
+        return self._responses.get(message.get("service", ""), {})
+
+
+def _get_all_resource(ws):
+    mcp = _FakeMcp()
+    register_ros_metadata_resources(mcp, ws)
+    return mcp.resources["ros-mcp://ros-metadata/all"]
+
+
+def test_get_all_metadata_handles_string_values_for_topics():
+    """Regression for #251.
+
+    rosbridge can return a *string* in ``values`` (e.g. when a service does not
+    exist). The topics block used ``response["values"].get(...)``, which raised
+    "'str' object has no attribute 'get'". It must instead degrade gracefully to
+    an empty topics list with no error recorded.
+    """
+    ws = _FakeWs({"/rosapi/topics": {"values": "service /rosapi/topics does not exist"}})
+    get_all = _get_all_resource(ws)
+
+    data = json.loads(get_all())  # must not raise
+
+    assert data["topics"] == []
+    assert not any("has no attribute" in err for err in data.get("errors", []))
+
+
+def test_get_all_metadata_parses_topics_with_types():
+    """Well-formed topics responses are paired with their types."""
+    ws = _FakeWs(
+        {
+            "/rosapi/topics": {
+                "values": {"topics": ["/a", "/b"], "types": ["std_msgs/String", "std_msgs/Int32"]}
+            }
+        }
+    )
+    get_all = _get_all_resource(ws)
+
+    data = json.loads(get_all())
+
+    assert data["topics"] == [
+        {"name": "/a", "type": "std_msgs/String"},
+        {"name": "/b", "type": "std_msgs/Int32"},
+    ]

--- a/tests/unit/test_ros_metadata_resources.py
+++ b/tests/unit/test_ros_metadata_resources.py
@@ -80,3 +80,30 @@ def test_get_all_metadata_parses_topics_with_types():
         {"name": "/a", "type": "std_msgs/String"},
         {"name": "/b", "type": "std_msgs/Int32"},
     ]
+
+
+def test_actions_type_resolved_from_interfaces_without_hardcoded_map():
+    """Regression for #317.
+
+    With the hardcoded action_type_map removed, the type must be derived from the
+    registered interfaces, matching by name across snake_case ↔ CamelCase. Uses an
+    action that was never in the old map, so it only resolves when the interface
+    lookup normalises underscores (follow_waypoints ↔ FollowWaypoints).
+    """
+    ws = _FakeWs(
+        {
+            "/rosapi/services": {"values": {"services": ["/rosapi/action_servers"]}},
+            "/rosapi/action_servers": {"values": {"action_servers": ["/nav/follow_waypoints"]}},
+            "/rosapi/interfaces": {
+                "values": {
+                    "interfaces": ["std_msgs/msg/String", "nav2_msgs/action/FollowWaypoints"]
+                }
+            },
+        }
+    )
+    mcp = _FakeMcp()
+    register_ros_metadata_resources(mcp, ws)
+    data = json.loads(mcp.resources["ros-mcp://ros-metadata/actions/all"]())
+
+    assert data["actions"]["/nav/follow_waypoints"]["type"] == "nav2_msgs/action/FollowWaypoints"
+    assert data["actions"]["/nav/follow_waypoints"]["status"] == "available"


### PR DESCRIPTION
## Summary

Fixes #317. `get_actions_details()` in `ros_metadata.py` carried a hardcoded `action_type_map` that mapped only `/turtle1/rotate_absolute`. This removes it and resolves every action's type from the registered action interfaces instead.

The interface name match now ignores case **and underscores**, so snake_case action names map to CamelCase interface types (`follow_waypoints` ↔ `FollowWaypoints`). The previous substring match would have failed on the underscore — so simply deleting the map without this would have regressed `rotate_absolute` to `unknown`.

> Note: `action_type_map` was already removed from `tools/actions.py` in step5 (#321). This was the remaining copy, in the metadata resource.

## Changes

- **`ros_mcp/resources/ros_metadata.py`** — remove `action_type_map`; always derive type via the interfaces lookup with underscore/case-insensitive matching.
- **`tests/unit/test_ros_metadata_resources.py`** — regression test using a non-turtlesim action (`/nav/follow_waypoints`); red before this change (resolves to `unknown`), green after.
- **`style:`** separate commit trimming the five verbose resource docstrings to one-liners (per request).

## Stacking

Based on `fix/issue-251-metadata-topics-string-values` (PR #343) because it builds on the same file + unit-test module. Retarget to `develop` once #343 merges.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)