### PR TITLE
fix(images): save images to a CWD-independent, configurable path

### DIFF
--- a/ros_mcp/tools/images.py
+++ b/ros_mcp/tools/images.py
@@ -8,6 +8,8 @@ from fastmcp.utilities.types import Image
 from mcp.types import ImageContent, ToolAnnotations
 from PIL import Image as PILImage
 
+from ros_mcp.utils.config_utils import get_image_path
+
 
 def convert_expects_image_hint(expects_image: str) -> bool | None:
     """
@@ -68,7 +70,7 @@ def register_image_tools(
         ),
     )
     def view_saved_image(
-        image_path: str = "./camera/received_image.jpeg",
+        image_path: str = "",
     ) -> ImageContent:  # type: ignore  # See issue #140
         """
         View a previously saved image from the specified path.
@@ -78,11 +80,14 @@ def register_image_tools(
         re-view a saved image without re-subscribing.
 
         Args:
-            image_path (str): Path to the saved image file (default: "./camera/received_image.jpeg")
+            image_path (str): Path to the saved image file. Defaults to the
+                auto-saved location (see get_image_path / ROS_MCP_IMAGE_DIR).
 
         Returns:
             ImageContent: JPEG-encoded image wrapped in an ImageContent object, or error dict if file not found.
         """
+        if not image_path:
+            image_path = get_image_path()
         if not os.path.exists(image_path):
             return {"error": f"No image found at {image_path}"}  # type: ignore[return-value]  # See issue #140
         img = PILImage.open(image_path)

--- a/ros_mcp/tools/topics.py
+++ b/ros_mcp/tools/topics.py
@@ -10,6 +10,7 @@ from mcp.types import TextContent, ToolAnnotations
 from PIL import Image as PILImage
 
 from ros_mcp.tools.images import _encode_image_to_imagecontent, convert_expects_image_hint
+from ros_mcp.utils.config_utils import get_image_path
 from ros_mcp.utils.response import _check_response, _safe_get_values
 from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager, parse_input
@@ -386,7 +387,7 @@ def register_topic_tools(
                     ws_manager.send(unsubscribe_msg)
                     # Return appropriate message based on whether image was actually parsed
                     if was_parsed_as_image:
-                        image_path = "./camera/received_image.jpeg"
+                        image_path = get_image_path()
                         if os.path.exists(image_path):
                             img = PILImage.open(image_path)
                             image_content = _encode_image_to_imagecontent(img)
@@ -537,7 +538,7 @@ def register_topic_tools(
                     msg_index = len(collected_messages)
                     # Add message based on whether it was actually parsed as image
                     if was_parsed_as_image:
-                        image_path = "./camera/received_image.jpeg"
+                        image_path = get_image_path()
                         if os.path.exists(image_path):
                             img = PILImage.open(image_path)
                             collected_messages.append(_encode_image_to_imagecontent(img))

--- a/ros_mcp/utils/config_utils.py
+++ b/ros_mcp/utils/config_utils.py
@@ -1,6 +1,39 @@
+import os
 from pathlib import Path
 
 import yaml
+
+# Default image output directory name, created under the user's home directory.
+_DEFAULT_IMAGE_DIR = Path.home() / ".ros-mcp" / "camera"
+
+
+def get_image_dir() -> str:
+    """Return the directory where received images are saved.
+
+    The location is independent of the current working directory so it works the
+    same whether the server runs via ``uv run`` (CWD inside the repo) or ``uvx``
+    (CWD set by the MCP client, often not writable — see issue #301). Defaults to
+    ``~/.ros-mcp/camera`` and can be overridden with the ``ROS_MCP_IMAGE_DIR``
+    environment variable.
+
+    Returns:
+        str: Absolute path to the image output directory.
+    """
+    env_dir = os.environ.get("ROS_MCP_IMAGE_DIR")
+    image_dir = Path(env_dir).expanduser() if env_dir else _DEFAULT_IMAGE_DIR
+    return str(image_dir)
+
+
+def get_image_path(filename: str = "received_image.jpeg") -> str:
+    """Return the full path for a saved image under :func:`get_image_dir`.
+
+    Args:
+        filename (str): Image file name. Defaults to ``received_image.jpeg``.
+
+    Returns:
+        str: Absolute path to the image file.
+    """
+    return str(Path(get_image_dir()) / filename)
 
 
 def load_robot_config(robot_name: str, specs_dir: str) -> dict:

--- a/ros_mcp/utils/websocket.py
+++ b/ros_mcp/utils/websocket.py
@@ -9,6 +9,8 @@ import cv2
 import numpy as np
 import websocket
 
+from ros_mcp.utils.config_utils import get_image_dir, get_image_path
+
 
 def parse_json(raw: Union[str, bytes] | None) -> dict | None:
     """
@@ -116,7 +118,7 @@ def parse_image(raw: Union[str, bytes] | None) -> dict | None:
         return None
 
     # 4. Ensure output directory exists
-    os.makedirs("./camera", exist_ok=True)
+    os.makedirs(get_image_dir(), exist_ok=True)
 
     # 5. Determine image type and process accordingly
     format = msg.get("format")
@@ -137,7 +139,7 @@ def parse_image(raw: Union[str, bytes] | None) -> dict | None:
 
 def _handle_compressed_image(data_b64: str, result: dict) -> dict | None:
     """Handle compressed image data (JPEG/PNG already encoded)."""
-    path = "./camera/received_image.jpeg"
+    path = get_image_path()
     image_bytes = base64.b64decode(data_b64)
 
     with open(path, "wb") as f:
@@ -170,9 +172,10 @@ def _handle_raw_image(
         return None
 
     # Save as JPEG with quality 95
-    success = cv2.imwrite("./camera/received_image.jpeg", img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
+    path = get_image_path()
+    success = cv2.imwrite(path, img_cv, [cv2.IMWRITE_JPEG_QUALITY, 95])
     if success:
-        print("[Image] Saved raw Image to ./camera/received_image.jpeg", file=sys.stderr)
+        print(f"[Image] Saved raw Image to {path}", file=sys.stderr)
         return result if isinstance(result, dict) else None
     else:
         return None

--- a/tests/unit/test_config_utils.py
+++ b/tests/unit/test_config_utils.py
@@ -6,6 +6,8 @@ import pytest
 
 import ros_mcp.utils.config_utils as config_module
 from ros_mcp.utils.config_utils import (
+    get_image_dir,
+    get_image_path,
     get_verified_robot_spec_util,
     get_verified_robots_list_util,
     load_robot_config,
@@ -136,3 +138,29 @@ class TestGetVerifiedRobotsListUtil:
         result = get_verified_robots_list_util()
         assert "error" in result
         assert "No robot specification files found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_image_dir / get_image_path — CWD-independent, env-overridable (issue #301)
+# ---------------------------------------------------------------------------
+
+
+class TestImagePath:
+    def test_default_dir_is_absolute_and_cwd_independent(self, monkeypatch):
+        monkeypatch.delenv("ROS_MCP_IMAGE_DIR", raising=False)
+        image_dir = get_image_dir()
+        assert Path(image_dir).is_absolute(), f"{image_dir} should not be CWD-relative"
+        assert Path(image_dir) == Path.home() / ".ros-mcp" / "camera"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("ROS_MCP_IMAGE_DIR", "/tmp/ros-mcp-images")
+        assert get_image_dir() == "/tmp/ros-mcp-images"
+
+    def test_env_override_expands_user(self, monkeypatch):
+        monkeypatch.setenv("ROS_MCP_IMAGE_DIR", "~/custom-images")
+        assert get_image_dir() == str(Path.home() / "custom-images")
+
+    def test_image_path_joins_filename(self, monkeypatch):
+        monkeypatch.setenv("ROS_MCP_IMAGE_DIR", "/tmp/imgs")
+        assert get_image_path() == str(Path("/tmp/imgs") / "received_image.jpeg")
+        assert get_image_path("frame.png") == str(Path("/tmp/imgs") / "frame.png")


### PR DESCRIPTION
## Summary

Fixes #301. Received images were saved to the CWD-relative `./camera/received_image.jpeg`. Under `uvx` / Claude Desktop the working directory is set by the client and often isn't writable, so saving failed with `Permission denied: './camera'` — while it worked under `uv run` from the repo. Behavior shouldn't depend on how the server is launched.

## Changes

- **`ros_mcp/utils/config_utils.py`** — new `get_image_dir()` / `get_image_path()`:
  - default `~/.ros-mcp/camera` (absolute, CWD-independent),
  - overridable via the `ROS_MCP_IMAGE_DIR` env var (with `~` expansion).
- **`ros_mcp/utils/websocket.py`** — `parse_image` / compressed / raw save paths now use the helpers (`os.makedirs(get_image_dir())`, `get_image_path()`).
- **`ros_mcp/tools/topics.py`** — image read-back paths use `get_image_path()`.
- **`ros_mcp/tools/images.py`** — `view_saved_image` defaults to the resolved saved location (empty arg → `get_image_path()`).
- **`tests/unit/test_config_utils.py`** — tests for default (absolute/CWD-independent), env override, `~` expansion, and filename join.

## Verification

`ruff` clean; `tests/unit/test_config_utils.py` 16 passed. Default resolves to `~/.ros-mcp/camera/received_image.jpeg` regardless of CWD.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)