### PR TITLE
fix(ci): unblock v3.1.0 publish (tests step)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         run: |
           if [ -d tests ]; then
-            uv run pytest -q -m "not slow" || [ $? -eq 5 ]  # exit 5 = no tests collected
+            uv run pytest -q -m "not slow and not integration" || [ $? -eq 5 ]  # exit 5 = no tests collected
           else
             echo "No tests/ directory; skipping."
           fi

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         run: |
           if [ -d tests ]; then
-            uv run pytest -q -m "not slow" || [ $? -eq 5 ]  # exit 5 = no tests collected
+            uv run pytest -q -m "not slow and not integration" || [ $? -eq 5 ]  # exit 5 = no tests collected
           else
             echo "No tests/ directory; skipping."
           fi

--- a/tests/integration/test_quick_detect.py
+++ b/tests/integration/test_quick_detect.py
@@ -27,41 +27,50 @@ from ros_mcp.utils.rosapi_types import (  # noqa: E402
 )
 from ros_mcp.utils.websocket import WebSocketManager  # noqa: E402
 
-ws = WebSocketManager("127.0.0.1", 9090, default_timeout=3.0)
-_reset_resolver()
 
-try:
-    detect_rosapi_types(ws)
-except DetectionError as e:
-    print(f"DETECTION FAILED: {e}")
-    print("This is expected if no rosbridge is running.")
-    sys.exit(1)
+def main() -> None:
+    ws = WebSocketManager("127.0.0.1", 9090, default_timeout=3.0)
+    _reset_resolver()
 
-version = get_ros_version()
-distro = get_distro()
+    try:
+        detect_rosapi_types(ws)
+    except DetectionError as e:
+        print(f"DETECTION FAILED: {e}")
+        print("This is expected if no rosbridge is running.")
+        sys.exit(1)
 
-print(f"version  = {version}")
-print(f"distro   = {distro!r}")
-print(f"prefix   = {rosapi_service('nodes')}")
-print(f"type     = {rosapi_type('Topics')}")
-print()
+    version = get_ros_version()
+    distro = get_distro()
 
-# Verify a real call works
-ws.connect()
-msg = {
-    "op": "call_service",
-    "service": rosapi_service("nodes"),
-    "type": rosapi_type("Nodes"),
-    "args": {},
-}
-ws.ws.send(json.dumps(msg))
-resp = json.loads(ws.ws.recv())
-ws.close()
+    print(f"version  = {version}")
+    print(f"distro   = {distro!r}")
+    print(f"prefix   = {rosapi_service('nodes')}")
+    print(f"type     = {rosapi_type('Topics')}")
+    print()
 
-if resp.get("result") is False:
-    print(f"SERVICE CALL FAILED: {resp}")
-    sys.exit(1)
+    # Verify a real call works
+    ws.connect()
+    msg = {
+        "op": "call_service",
+        "service": rosapi_service("nodes"),
+        "type": rosapi_type("Nodes"),
+        "args": {},
+    }
+    ws.ws.send(json.dumps(msg))
+    resp = json.loads(ws.ws.recv())
+    ws.close()
 
-nodes = resp.get("values", {}).get("nodes", [])
-print(f"nodes    = {nodes}")
-print(f"result   = OK ({len(nodes)} nodes found)")
+    if resp.get("result") is False:
+        print(f"SERVICE CALL FAILED: {resp}")
+        sys.exit(1)
+
+    nodes = resp.get("values", {}).get("nodes", [])
+    print(f"nodes    = {nodes}")
+    print(f"result   = OK ({len(nodes)} nodes found)")
+
+
+# Guard execution so pytest can import this module during collection without
+# attempting a live rosbridge connection (which aborts the whole test session).
+# Run manually with: uv run python tests/integration/test_quick_detect.py
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
The **Publish (PyPI + MCP Registry)** run for `v3.1.0` failed at the **Run tests** step, before anything was built or published (PyPI still shows 3.0.1 as latest). Two separate causes:

1. **Collection abort** — `tests/integration/test_quick_detect.py` ran a live rosbridge connection at *module level*. pytest imports every `test_*.py` during collection, so with no rosbridge it called `sys.exit(1)` → `INTERNALERROR` → "no tests ran" → exit 1.
2. **Wrong test selector** — the publish job ran `pytest -m "not slow"`. The 8 integration test files are marked `integration` (not `slow`), so they were *not* deselected and would trigger `docker compose up --build` inside the publish job.

## Fix
- Guard `test_quick_detect.py`'s body behind `if __name__ == "__main__"`. pytest now imports it with no side effects (0 tests collected). Standalone usage is unchanged — `integration-tests.yml` still runs it as `python tests/integration/test_quick_detect.py`.
- Publish workflows (`publish.yml`, `publish_pypi.yml`) now run `pytest -m "not slow and not integration"`. Only unit tests gate publishing; integration tests stay in `integration-tests.yml` where ROS containers are provisioned.

## Verification (local)
- `pytest --collect-only tests/integration/test_quick_detect.py` → 0 collected, no INTERNALERROR
- `pytest -q -m "not slow and not integration"` → 12 passed, 126 deselected
- `ruff check` + `ruff format --check` clean

## Release note
This is a hotfix for the tagged-but-unpublished **v3.1.0**. After merge, the `v3.1.0` tag will be moved to the new `main` HEAD (version stays 3.1.0 since nothing was published) and the publish workflow re-run.