### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -27,6 +27,14 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 claude mcp add ros-mcp -- uvx ros-mcp --transport=stdio
 ```
 
+Quick setup with [Autohand Code](https://github.com/autohandai/code-cli/):
+
+```bash
+autohand mcp add ros-mcp -- uvx ros-mcp --transport=stdio
+```
+
+Add `--scope project` after `mcp add` to keep the registration in the current workspace.
+
 For detailed instructions or to set up a different AI client, follow the guide for your client below.
 
 


### PR DESCRIPTION
## Summary

Add an Autohand Code quick-start command beside the existing Claude Code setup. It uses the same published `uvx ros-mcp --transport=stdio` server entry point and documents project scope.

This PR targets `develop` as required by the contribution guide.

## Verification

- `uv run --with ruff ruff format --check .`
- `uv run --with ruff ruff check .`
- `git diff --check`