### PR TITLE
fix(metadata): guard topics block against non-dict rosbridge values

### DIFF
--- a/ros_mcp/resources/ros_metadata.py
+++ b/ros_mcp/resources/ros_metadata.py
@@ -55,9 +55,12 @@ def register_ros_metadata_resources(mcp, ws_manager: WebSocketManager):
                 }
                 with ws_manager:
                     response = ws_manager.request(topics_message)
-                    if response and "values" in response:
-                        topics = response["values"].get("topics", [])
-                        types = response["values"].get("types", [])
+                    # rosbridge may put a string in values when a service is missing
+                    # (issue #251 / PR #343). Mirror services/nodes safe extraction.
+                    values = _safe_get_values(response)
+                    if values is not None:
+                        topics = values.get("topics", [])
+                        types = values.get("types", [])
                         # Handle case where types might be empty or missing
                         if types and len(types) == len(topics):
                             metadata["topics"] = [

--- a/tests/unit/test_ros_metadata_resources.py
+++ b/tests/unit/test_ros_metadata_resources.py
@@ -40,6 +40,7 @@ def _get_all_resource(ws):
 
 def test_get_all_metadata_handles_string_values_for_topics():
     """Regression for #251 / salvage of #343."""
+
     # Service path is version-dependent; cover both common keys by emptying responses
     # except one string-values topics entry via side_effect-like map on full service names.
     # Map by scanning keys in request: our Fake uses service field as key.

--- a/tests/unit/test_ros_metadata_resources.py
+++ b/tests/unit/test_ros_metadata_resources.py
@@ -1,0 +1,74 @@
+"""Unit tests for ros-metadata MCP resources (no live rosbridge)."""
+
+import json
+
+from ros_mcp.resources.ros_metadata import register_ros_metadata_resources
+
+
+class _FakeMcp:
+    def __init__(self):
+        self.resources = {}
+
+    def resource(self, uri):
+        def decorator(fn):
+            self.resources[uri] = fn
+            return fn
+
+        return decorator
+
+
+class _FakeWs:
+    def __init__(self, responses):
+        self._responses = responses
+        self.default_timeout = 2.0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def request(self, message, timeout=None):
+        return self._responses.get(message.get("service", ""), {})
+
+
+def _get_all_resource(ws):
+    mcp = _FakeMcp()
+    register_ros_metadata_resources(mcp, ws)
+    return mcp.resources["ros-mcp://ros-metadata/all"]
+
+
+def test_get_all_metadata_handles_string_values_for_topics():
+    """Regression for #251 / salvage of #343."""
+    # Service path is version-dependent; cover both common keys by emptying responses
+    # except one string-values topics entry via side_effect-like map on full service names.
+    # Map by scanning keys in request: our Fake uses service field as key.
+    # Use both rosapi and rosapi_namespaced possibilities by monkeypatching responses for any.
+    class WS(_FakeWs):
+        def request(self, message, timeout=None):
+            if "topics" in message.get("service", ""):
+                return {"values": "service /rosapi/topics does not exist"}
+            return {}
+
+    data = json.loads(_get_all_resource(WS({}))())
+    assert data["topics"] == []
+    assert not any("has no attribute" in err for err in data.get("errors", []))
+
+
+def test_get_all_metadata_parses_topics_with_types():
+    class WS(_FakeWs):
+        def request(self, message, timeout=None):
+            if "topics" in message.get("service", ""):
+                return {
+                    "values": {
+                        "topics": ["/a", "/b"],
+                        "types": ["std_msgs/String", "std_msgs/Int32"],
+                    }
+                }
+            return {}
+
+    data = json.loads(_get_all_resource(WS({}))())
+    assert data["topics"] == [
+        {"name": "/a", "type": "std_msgs/String"},
+        {"name": "/b", "type": "std_msgs/Int32"},
+    ]


### PR DESCRIPTION
## Summary
- Use `_safe_get_values(response)` for the topics block in `get_all_ros_metadata` (same helper as services/nodes).
- Add unit tests that string `values` do not raise and well-formed topics still pair with types.

## Motivation
Fixes #251. rosbridge can return a string in `values` when a service is missing; the topics block still did `response[\"values\"].get(...)`.

Salvage of #343 by @stex2005 — rebased to `main` (original targeted `develop` and was conflicting).

## Verification
- `python3 -m pytest tests/unit/test_ros_metadata_resources.py -q`

## Attribution
Salvage of #343 by @stex2005 — rebased to main