### PR TITLE
test(unit): cover convert_expects_image_hint mapping

### DIFF
--- a/tests/unit/test_expects_image_hint.py
+++ b/tests/unit/test_expects_image_hint.py
@@ -1,0 +1,27 @@
+"""Unit tests for convert_expects_image_hint (pure mapping)."""
+
+from ros_mcp.tools.images import convert_expects_image_hint
+
+
+class TestConvertExpectsImageHint:
+    def test_true_string(self):
+        assert convert_expects_image_hint("true") is True
+
+    def test_false_string(self):
+        assert convert_expects_image_hint("false") is False
+
+    def test_auto_string(self):
+        assert convert_expects_image_hint("auto") is None
+
+    def test_empty_string_is_auto(self):
+        assert convert_expects_image_hint("") is None
+
+    def test_unknown_is_auto(self):
+        assert convert_expects_image_hint("maybe") is None
+        assert convert_expects_image_hint("TRUE") is None
+        assert convert_expects_image_hint("False") is None
+
+    def test_whitespace_not_true(self):
+        # Only exact "true"/"false" match; surrounding space is auto
+        assert convert_expects_image_hint(" true") is None
+        assert convert_expects_image_hint("false ") is None


### PR DESCRIPTION
## Summary
Adds offline unit coverage for `convert_expects_image_hint` in `ros_mcp/tools/images.py`.

The helper is the string→bool|None gate that drives image vs JSON parsing. These cases lock the exact `"true"` / `"false"` match (case-sensitive) and auto fallthrough for empty, mixed-case, and unknown values.

## Test plan
- [x] `uv run pytest tests/unit/test_expects_image_hint.py -q` (6 passed, offline)

## Notes
Tests-only. AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->

