### PR TITLE
test(unit): cover WebSocketManager.send success and error paths

### DIFF
--- a/tests/unit/test_websocket_send.py
+++ b/tests/unit/test_websocket_send.py
@@ -1,0 +1,67 @@
+"""Unit tests for WebSocketManager.send paths."""
+
+from unittest.mock import MagicMock, patch
+
+from ros_mcp.utils.websocket import WebSocketManager
+
+
+class TestWebSocketManagerSend:
+    def test_send_returns_none_on_success(self):
+        mgr = WebSocketManager("127.0.0.1", 9090)
+        mock_ws = MagicMock()
+        mock_ws.connected = True
+        mgr.ws = mock_ws
+
+        with patch.object(mgr, "connect", return_value=None) as connect:
+            err = mgr.send({"op": "call_service", "id": "1"})
+            connect.assert_called_once()
+        assert err is None
+        mock_ws.send.assert_called_once()
+        payload = mock_ws.send.call_args[0][0]
+        assert '"op": "call_service"' in payload or '"op":"call_service"' in payload.replace(
+            " ", ""
+        )
+
+    def test_send_returns_connect_error(self):
+        mgr = WebSocketManager("127.0.0.1", 9090)
+        with patch.object(mgr, "connect", return_value="[WebSocket] Connection error: boom"):
+            err = mgr.send({"op": "advertise"})
+        assert err == "[WebSocket] Connection error: boom"
+
+    def test_send_serialization_error_closes(self):
+        mgr = WebSocketManager("127.0.0.1", 9090)
+        mock_ws = MagicMock()
+        mock_ws.connected = True
+        mgr.ws = mock_ws
+
+        with patch.object(mgr, "connect", return_value=None):
+            with patch("ros_mcp.utils.websocket.json.dumps", side_effect=TypeError("not serializable")):
+                err = mgr.send({"bad": object()})
+        assert err is not None
+        assert "serialization" in err.lower() or "JSON" in err
+        assert mgr.ws is None
+        mock_ws.close.assert_called()
+
+    def test_send_generic_exception_closes(self):
+        mgr = WebSocketManager("127.0.0.1", 9090)
+        mock_ws = MagicMock()
+        mock_ws.connected = True
+        mock_ws.send.side_effect = OSError("broken pipe")
+        mgr.ws = mock_ws
+
+        with patch.object(mgr, "connect", return_value=None):
+            err = mgr.send({"op": "ping"})
+        assert err is not None
+        assert "Send error" in err
+        assert mgr.ws is None
+
+    def test_send_aborts_when_ws_missing_after_connect(self):
+        mgr = WebSocketManager("127.0.0.1", 9090)
+
+        def _connect_ok_but_clear():
+            mgr.ws = None
+            return None
+
+        with patch.object(mgr, "connect", side_effect=_connect_ok_but_clear):
+            err = mgr.send({"op": "x"})
+        assert err == "[WebSocket] Not connected, send aborted."


### PR DESCRIPTION
### What
Adds `tests/unit/test_websocket_send.py` covering send happy path, connect failure, JSON serialization TypeError (close), generic send Exception (close), and "not connected" when `ws` is cleared after connect.

### Why
Defensive coverage for rosbridge send error surfaces used by every tool path.

### Verify
```bash
pytest tests/unit/test_websocket_send.py -q
```
5 passed offline.

Independent of the receive-path test PR. Human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->

