### PR TITLE
test(unit): cover get_node_details empty name validation

### DIFF
--- a/tests/unit/test_node_empty_name.py
+++ b/tests/unit/test_node_empty_name.py
@@ -1,0 +1,127 @@
+"""Unit tests for nodes.get_node_details empty-name validation (no rosbridge)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_NODES_PATH = _ROOT / "ros_mcp" / "tools" / "nodes.py"
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, *args, **kwargs):
+        def decorator(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+class FakeWsManager:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def request(self, message):
+        raise AssertionError(f"ws should not be called for empty name; got {message!r}")
+
+
+def _ensure_stub(name: str) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    try:
+        return __import__(name)
+    except ImportError:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+
+def _ensure_pkg(name: str) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_nodes_module():
+    _ensure_stub("cv2")
+    _ensure_stub("numpy")
+    _ensure_stub("websocket")
+    _ensure_stub("yaml")
+
+    fastmcp = _ensure_stub("fastmcp")
+    fastmcp.FastMCP = object  # type: ignore[attr-defined]
+
+    mcp_types = _ensure_pkg("mcp.types")
+
+    class ToolAnnotations:  # minimal kwargs-accepting stub
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    mcp_types.ToolAnnotations = ToolAnnotations  # type: ignore[attr-defined]
+    _ensure_pkg("mcp").types = mcp_types  # type: ignore[attr-defined]
+
+    _ensure_pkg("ros_mcp")
+    tools = _ensure_pkg("ros_mcp.tools")
+    utils = _ensure_pkg("ros_mcp.utils")
+
+    response = types.ModuleType("ros_mcp.utils.response")
+    response._check_response = lambda r: None  # type: ignore[attr-defined]
+    response._safe_get_values = lambda r: None  # type: ignore[attr-defined]
+    sys.modules["ros_mcp.utils.response"] = response
+    utils.response = response  # type: ignore[attr-defined]
+
+    rosapi = types.ModuleType("ros_mcp.utils.rosapi_types")
+    rosapi.rosapi_service = lambda n: f"/rosapi/{n}"  # type: ignore[attr-defined]
+    rosapi.rosapi_type = lambda n: f"rosapi/{n}"  # type: ignore[attr-defined]
+    sys.modules["ros_mcp.utils.rosapi_types"] = rosapi
+    utils.rosapi_types = rosapi  # type: ignore[attr-defined]
+
+    websocket_mod = types.ModuleType("ros_mcp.utils.websocket")
+    websocket_mod.WebSocketManager = object  # type: ignore[attr-defined]
+    sys.modules["ros_mcp.utils.websocket"] = websocket_mod
+    utils.websocket = websocket_mod  # type: ignore[attr-defined]
+
+    spec = importlib.util.spec_from_file_location("ros_mcp_tools_nodes_empty_ut", _NODES_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    tools.nodes = mod  # type: ignore[attr-defined]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def get_node_details():
+    mod = _load_nodes_module()
+    mcp = FakeMCP()
+    mod.register_node_tools(mcp, FakeWsManager())
+    assert "get_node_details" in mcp.tools
+    return mcp.tools["get_node_details"]
+
+
+class TestGetNodeDetailsEmptyName:
+    def test_empty_string(self, get_node_details):
+        result = get_node_details("")
+        assert result == {"error": "Node name cannot be empty"}
+
+    def test_whitespace_only(self, get_node_details):
+        result = get_node_details("   ")
+        assert result == {"error": "Node name cannot be empty"}
+
+    def test_tabs_and_newlines(self, get_node_details):
+        result = get_node_details("\t\n")
+        assert result == {"error": "Node name cannot be empty"}


### PR DESCRIPTION
## Summary
Offline unit tests for `get_node_details` early validation when the node name is empty or whitespace-only.

- Does not open a WebSocket (FakeWs asserts not called)
- Covers `""`, spaces, and tab/newline-only input

Tests-only.

## Motivation
Empty-name guard on node details had no unit coverage; cheap safety net beside heavier integration/action suites.

## Verification
```
python3 -m pytest tests/unit/test_node_empty_name.py -q
# 3 passed
```

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->

