### PR TITLE
fix(websocket): keep connection open on receive timeout

### DIFF
--- a/ros_mcp/utils/websocket.py
+++ b/ros_mcp/utils/websocket.py
@@ -283,6 +283,36 @@ def _handle_auto_detection(raw: Union[str, bytes], parsed_data: dict) -> tuple[d
     return parsed_data, False
 
 
+def _is_websocket_timeout(exc: BaseException) -> bool:
+    """Return True if *exc* is a socket/websocket read timeout (not a hard error)."""
+    if isinstance(exc, TimeoutError):
+        return True
+    # stdlib socket.timeout is an OSError subclass (alias of TimeoutError on 3.10+)
+    try:
+        import socket
+
+        if isinstance(exc, socket.timeout):
+            return True
+    except Exception:
+        pass
+    # websocket-client
+    try:
+        from websocket import WebSocketTimeoutException
+
+        if isinstance(exc, WebSocketTimeoutException):
+            return True
+    except Exception:
+        pass
+    # Some backends raise OSError with errno EAGAIN/EWOULDBLOCK or timed out message
+    name = type(exc).__name__.lower()
+    if "timeout" in name:
+        return True
+    msg = str(exc).lower()
+    if "timed out" in msg or "timeout" == msg.strip():
+        return True
+    return False
+
+
 class WebSocketManager:
     def __init__(self, ip: str, port: int, default_timeout: float = 2.0):
         self.ip = ip
@@ -364,6 +394,12 @@ class WebSocketManager:
 
         Returns:
             str | None: JSON string received from rosbridge, or None if timeout/error.
+
+        Note:
+            Read timeouts return None without closing the connection. Closing on
+            timeout drops roslibjs/rosbridge subscriptions on the next reconnect
+            (see issue #318 / send_action_goal feedback loops). Real socket errors
+            still call close().
         """
         with self.lock:
             self.connect()
@@ -377,7 +413,12 @@ class WebSocketManager:
                     raw = self.ws.recv()  # rosbridge sends JSON as a string
                     return raw
                 except Exception as e:
-                    print(f"[WebSocket] Receive error or timeout: {e}", file=sys.stderr)
+                    # Keep connection open on read timeout so long-running action
+                    # feedback loops do not lose their rosbridge subscription.
+                    if _is_websocket_timeout(e):
+                        print(f"[WebSocket] Receive timeout: {e}", file=sys.stderr)
+                        return None
+                    print(f"[WebSocket] Receive error: {e}", file=sys.stderr)
                     self.close()
                     return None
             return None

--- a/tests/unit/test_websocket_receive_timeout_keeps_connection.py
+++ b/tests/unit/test_websocket_receive_timeout_keeps_connection.py
@@ -1,0 +1,51 @@
+"""WebSocketManager.receive must not close the socket on read timeout (#318)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ros_mcp.utils.websocket import WebSocketManager, _is_websocket_timeout
+
+
+def test_is_websocket_timeout_helpers():
+    assert _is_websocket_timeout(TimeoutError("timed out"))
+    assert _is_websocket_timeout(TimeoutError())
+    assert not _is_websocket_timeout(RuntimeError("boom"))
+    assert _is_websocket_timeout(OSError("timed out"))
+
+
+def test_receive_timeout_returns_none_without_close():
+    mgr = WebSocketManager("127.0.0.1", 9090, default_timeout=0.1)
+    fake = MagicMock()
+    fake.connected = True
+    fake.recv.side_effect = TimeoutError("timed out")
+    mgr.ws = fake
+
+    # spy close
+    closed = {"n": 0}
+    orig_close = mgr.close
+
+    def _close():
+        closed["n"] += 1
+        return orig_close()
+
+    mgr.close = _close  # type: ignore[method-assign]
+
+    out = mgr.receive(timeout=0.05)
+    assert out is None
+    assert closed["n"] == 0
+    fake.recv.assert_called()
+    # connection still held
+    assert mgr.ws is fake
+
+
+def test_receive_hard_error_still_closes():
+    mgr = WebSocketManager("127.0.0.1", 9090, default_timeout=0.1)
+    fake = MagicMock()
+    fake.connected = True
+    fake.recv.side_effect = RuntimeError("connection reset")
+    mgr.ws = fake
+
+    out = mgr.receive(timeout=0.05)
+    assert out is None
+    assert mgr.ws is None


### PR DESCRIPTION
## Summary
`WebSocketManager.receive()` used to call `close()` on **any** exception, including read timeouts. During `send_action_goal`, a short gap between `action_feedback` frames can time out `recv()`, drop the socket, and lose the action subscription on reconnect — so the tool reports timeout even when the action succeeded (`get_action_status` = SUCCEEDED).

This keeps the connection open on read timeout (returns `None` as before) and only closes on real socket/protocol errors.

Fixes #318

## Changes
- `ros_mcp/utils/websocket.py` — `_is_websocket_timeout()` + receive path split
- `tests/unit/test_websocket_receive_timeout_keeps_connection.py` — offline coverage

## Test plan
- [x] `pytest tests/unit/test_websocket_receive_timeout_keeps_connection.py -q` (3 passed)
- [x] `ruff check` on touched files

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->