### PR TITLE
fix(tests): compare image dir against a platform-native path

### DIFF
--- a/tests/unit/test_config_utils.py
+++ b/tests/unit/test_config_utils.py
@@ -154,7 +154,7 @@ class TestImagePath:
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("ROS_MCP_IMAGE_DIR", "/tmp/ros-mcp-images")
-        assert get_image_dir() == "/tmp/ros-mcp-images"
+        assert get_image_dir() == str(Path("/tmp/ros-mcp-images"))
 
     def test_env_override_expands_user(self, monkeypatch):
         monkeypatch.setenv("ROS_MCP_IMAGE_DIR", "~/custom-images")


### PR DESCRIPTION
`tests/unit/test_config_utils.py::TestImagePath::test_env_override` compares `get_image_dir()` against a hardcoded POSIX string, so it fails on Windows:

```
Windows  (Python 3.10.21):  1 failed, 18 passed
  assert get_image_dir() == "/tmp/ros-mcp-images"
  AssertionError: assert '\tmp\ros-mcp-images' == '/tmp/ros-mcp-images'

Linux    (Ubuntu 22.04/WSL2, Python 3.10.12, same commit):  19 passed
```

The implementation is correct: `get_image_dir()` returns `str(Path(...))`, and `WindowsPath` normalises the separators. It is the expectation that is platform-specific. The two sibling tests in the same class already build their expected value with `str(Path(...))`, so this just applies the same convention to the third.

Every CI job runs `ubuntu-latest`, including `publish.yml` and `publish_pypi.yml`, so this is currently invisible upstream and the unit suite is red for anyone developing on Windows.

Verified on Windows 11 / Python 3.10.21 (`19 passed` after) and on Ubuntu 22.04 under WSL2 / Python 3.10.12 (`19 passed`, unchanged). Branched from `develop`.
