### PR TITLE
fix(network): parse Windows ping round-trip times

### DIFF
--- a/ros_mcp/utils/network_utils.py
+++ b/ros_mcp/utils/network_utils.py
@@ -1,7 +1,31 @@
 import platform
+import re
 import socket
 import subprocess
 from typing import Dict, Tuple
+
+# Round-trip time as printed by ping. The unit spacing differs by platform:
+# Linux prints "time=0.057 ms", Windows prints "time=3ms" and, for
+# sub-millisecond replies, "time<1ms".
+_PING_TIME_RE = re.compile(r"time[=<]\s*(\d+(?:\.\d+)?)\s*ms")
+
+
+def _parse_ping_time_ms(output: str) -> float | None:
+    """
+    Extract the round-trip time in milliseconds from ping's stdout.
+
+    Args:
+        output (str): Raw stdout captured from the platform ping command.
+
+    Returns:
+        float | None: Round-trip time in milliseconds, or None if ping did not
+        report one. A Windows "time<1ms" reading is returned as its upper bound
+        (1.0), because ping does not print a more precise value.
+    """
+    match = _PING_TIME_RE.search(output)
+    if match is None:
+        return None
+    return float(match.group(1))
 
 
 def _resolve_dns(hostname: str) -> Tuple[bool, str | None, str | None]:
@@ -89,19 +113,7 @@ def ping_ip_and_port(
         )
 
         if ping_result.returncode == 0:
-            # Extract response time from ping output
-            output_lines = ping_result.stdout.split("\n")
-            for line in output_lines:
-                if "time=" in line or "time<" in line:
-                    # Extract time value (format varies by OS)
-                    if "time=" in line:
-                        time_part = line.split("time=")[1].split()[0]
-                        try:
-                            result["ping"]["response_time_ms"] = float(time_part)
-                        except ValueError:
-                            result["ping"]["response_time_ms"] = None
-                    break
-
+            result["ping"]["response_time_ms"] = _parse_ping_time_ms(ping_result.stdout)
             result["ping"]["success"] = True
         else:
             result["ping"]["error"] = f"Ping failed with return code {ping_result.returncode}"

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,0 +1,108 @@
+"""Unit tests for ros_mcp/utils/network_utils.py."""
+
+from unittest.mock import MagicMock, patch
+
+from ros_mcp.utils.network_utils import _parse_ping_time_ms, ping_ip_and_port
+
+# ---------------------------------------------------------------------------
+# Ping output captured verbatim from each platform, used as parser input.
+# ---------------------------------------------------------------------------
+
+WINDOWS_SUB_MILLISECOND = """
+Pinging 127.0.0.1 with 32 bytes of data:
+Reply from 127.0.0.1: bytes=32 time<1ms TTL=128
+
+Ping statistics for 127.0.0.1:
+    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 0ms, Maximum = 0ms, Average = 0ms
+"""
+
+WINDOWS_INTEGER_MILLISECONDS = """
+Pinging 8.8.8.8 with 32 bytes of data:
+Reply from 8.8.8.8: bytes=32 time=9ms TTL=115
+
+Ping statistics for 8.8.8.8:
+    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 9ms, Maximum = 9ms, Average = 9ms
+"""
+
+LINUX_FRACTIONAL_MILLISECONDS = """PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
+64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.057 ms
+
+--- 127.0.0.1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 0.057/0.057/0.057/0.000 ms
+"""
+
+WINDOWS_TIMED_OUT = """
+Pinging 192.168.223.254 with 32 bytes of data:
+Request timed out.
+
+Ping statistics for 192.168.223.254:
+    Packets: Sent = 1, Received = 0, Lost = 1 (100% loss),
+"""
+
+
+# ---------------------------------------------------------------------------
+# _parse_ping_time_ms — pure parser, exercised against every output format
+# ---------------------------------------------------------------------------
+
+
+class TestParsePingTimeMs:
+    def test_windows_sub_millisecond_reply(self):
+        # Windows prints "time<1ms"; 1.0 is the tightest bound ping gives us.
+        assert _parse_ping_time_ms(WINDOWS_SUB_MILLISECOND) == 1.0
+
+    def test_windows_integer_milliseconds(self):
+        # Windows prints no space before the unit ("time=9ms").
+        assert _parse_ping_time_ms(WINDOWS_INTEGER_MILLISECONDS) == 9.0
+
+    def test_linux_fractional_milliseconds(self):
+        # Linux prints a space before the unit ("time=0.057 ms").
+        assert _parse_ping_time_ms(LINUX_FRACTIONAL_MILLISECONDS) == 0.057
+
+    def test_linux_summary_line_is_not_read_as_a_reply(self):
+        # The Linux summary carries "time 0ms" (elapsed run time, not an RTT).
+        summary = "1 packets transmitted, 1 received, 0% packet loss, time 0ms\n"
+        assert _parse_ping_time_ms(summary) is None
+
+    def test_timed_out_output_returns_none(self):
+        assert _parse_ping_time_ms(WINDOWS_TIMED_OUT) is None
+
+    def test_empty_output_returns_none(self):
+        assert _parse_ping_time_ms("") is None
+
+
+# ---------------------------------------------------------------------------
+# ping_ip_and_port — response_time_ms is populated on every platform
+# ---------------------------------------------------------------------------
+
+
+class TestPingIpAndPortResponseTime:
+    @staticmethod
+    def _ping_with_stdout(stdout: str, returncode: int = 0) -> dict:
+        """Run ping_ip_and_port with the ping command and socket both stubbed."""
+        with (
+            patch("ros_mcp.utils.network_utils.subprocess.run") as run_mock,
+            patch("ros_mcp.utils.network_utils.socket.socket") as socket_mock,
+        ):
+            run_mock.return_value = MagicMock(returncode=returncode, stdout=stdout)
+            socket_mock.return_value.connect_ex.return_value = 0
+            return ping_ip_and_port("127.0.0.1", 9090)
+
+    def test_windows_reply_reports_response_time(self):
+        result = self._ping_with_stdout(WINDOWS_INTEGER_MILLISECONDS)
+        assert result["ping"]["success"] is True
+        assert result["ping"]["response_time_ms"] == 9.0
+
+    def test_linux_reply_reports_response_time(self):
+        result = self._ping_with_stdout(LINUX_FRACTIONAL_MILLISECONDS)
+        assert result["ping"]["success"] is True
+        assert result["ping"]["response_time_ms"] == 0.057
+
+    def test_failed_ping_leaves_response_time_unset(self):
+        result = self._ping_with_stdout(WINDOWS_TIMED_OUT, returncode=1)
+        assert result["ping"]["success"] is False
+        assert result["ping"]["response_time_ms"] is None


### PR DESCRIPTION
`ping_ip_and_port` reports `response_time_ms` as `null` on Windows even for a successful ping.

The parser splits the reply line on `time=` and passes the next whitespace-delimited token to `float()`. Linux prints a space before the unit (`time=0.057 ms`), so the token is `0.057` and parses. Windows prints none (`time=9ms`), so the token is `9ms` and `float()` raises, and the value is discarded. The sub-millisecond form `time<1ms` matched the outer condition but the inner branch tested for `time=` only, so it never reached a parse at all.

### Reproduction

Same commit, same source file, same targets:

```
Windows:  127.0.0.1 -> {"success": true, "response_time_ms": null}   (raw ping: time<1ms)
          8.8.8.8   -> {"success": true, "response_time_ms": null}   (raw ping: time=9ms)
Linux:    127.0.0.1 -> {"success": true, "response_time_ms": 0.136}
```

Through the MCP `ping_robots` tool on Windows, before and after:

```
before:  127.0.0.1 response_time_ms=null   8.8.8.8 response_time_ms=null
after:   127.0.0.1 response_time_ms=1.0    8.8.8.8 response_time_ms=13.0
```

### The change

Extracts `_parse_ping_time_ms()` and matches with `re.compile(r"time[=<]\s*(\d+(?:\.\d+)?)\s*ms")`, which tolerates both forms. A Windows `time<1ms` reading is reported as its upper bound of 1.0, because ping does not print anything more precise. Linux's summary line `...packet loss, time 0ms` is not a round-trip time and is deliberately not matched, since the pattern requires `time=` or `time<`.

Adds `tests/unit/test_network_utils.py` with 9 tests over captured output from both platforms, so the Windows format is exercised on any runner. Against the current parser these go red (`assert None == 9.0`) and green with the fix.

### Notes

- Tested on Windows 11 / Python 3.10.21 and Ubuntu 22.04 under WSL2 / Python 3.10.12. **Not tested on macOS** — I have no macOS host; the space-separated form is covered by the Linux fixture. Live Linux behaviour is unchanged (`0.024`, `9.38`).
- **Not handled:** localised Windows builds print a translated label (for example `Zeit=`), which this pattern does not match. Happy to add that if you want it.
- **Overlap:** #351 also adds `tests/unit/test_network_utils.py`. Its fixtures are Linux-format only (`time=1.2 ms`, `time=2 ms`), so it would pass on Windows while this bug still stands. Glad to rebase onto it if it lands first, or to fold these fixtures into it instead.
- Branched from `develop`. The full unit suite is `27 passed` on Windows plus the one pre-existing failure fixed in #388, and `28 passed` on Linux.
